### PR TITLE
Replace suppression of IDE0067 with CA2000

### DIFF
--- a/src/SignService/Utils/AutoRestCredential.cs
+++ b/src/SignService/Utils/AutoRestCredential.cs
@@ -124,9 +124,9 @@ namespace SignService.Utils
 
                 // if this credential is tied to a specific TClient reuse it's HttpClient to send the 
                 // initial unauthed request to get the challange, otherwise create a new HttpClient
-#pragma warning disable IDE0067 // Dispose objects before losing scope
+#pragma warning disable CA2000 // Dispose objects before losing scope
                 var client = this.client?.HttpClient ?? new HttpClient();
-#pragma warning restore IDE0067 // Dispose objects before losing scope
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
                 using (var r = new HttpRequestMessage(request.Method, request.RequestUri))
                 {


### PR DESCRIPTION
The IDE dispose analyzer rules have been deleted from Roslyn:

https://github.com/dotnet/roslyn/commit/eeba499ecf839ec35bca25062d69d2fc5c4885b9

CA2000 is the replacement for IDE0067.

cc: @clairernovotny