### PR TITLE
Update Microsoft.AspNetCore.Server.Kestrel.Core to v2.3.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <PackageVersion Include="Microsoft.Dynamics.BusinessCentral.Sip.Main" Version="24.0.15760" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.9" />

--- a/test/Sign.Core.Test/Sign.Core.Test.csproj
+++ b/test/Sign.Core.Test/Sign.Core.Test.csproj
@@ -14,6 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <!-- Add an explicit reference to updated Kestrel.Core package version to bring in fix for CVE-2025-55315 -->
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
     <!-- Microsoft.AspNetCore.Server.Kestrel is old and requires an older version of Microsoft.Extensions.Primitives to function. -->
     <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="2.2.0" />
     <PackageReference Include="Moq" />


### PR DESCRIPTION
Context: https://github.com/advisories/GHSA-5rrx-jjjq-q2r5

Adds an explicit reference to Microsoft.AspNetCore.Server.Kestrel.Core
version 2.3.6 to address https://github.com/advisories/GHSA-5rrx-jjjq-q2r5.