### PR TITLE
Enable transitive package pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.CodeSigning.Sdk" Version="0.1.164" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/954

This change enables [`CentralPackageTransitivePinningEnabled`](https://learn.microsoft.com/nuget/consume-packages/central-package-management#transitive-pinning) in `Directory.Packages.props` to enforce version pinning for transitive dependencies when using NuGet's central package management. This helps ensure that transitive dependencies are pinned to specific versions, improving build consistency and reducing potential dependency conflicts.