### PR TITLE
Update to System.CommandLine 2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="NuGet.Packaging" Version="7.0.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />

--- a/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
+++ b/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Sign.Cli {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AzureKeyVaultResources {
@@ -93,6 +93,15 @@ namespace Sign.Cli {
         internal static string InvalidKeyVaultUrl {
             get {
                 return ResourceManager.GetString("InvalidKeyVaultUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URL must be an absolute HTTPS URL to an Azure Key Vault..
+        /// </summary>
+        internal static string InvalidUrlValue {
+            get {
+                return ResourceManager.GetString("InvalidUrlValue", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -129,6 +129,9 @@
   <data name="InvalidKeyVaultUrl" xml:space="preserve">
     <value>URL must only contain the protocol and host. (e.g.: https://&lt;vault-name&gt;.vault.azure.net/)</value>
   </data>
+  <data name="InvalidUrlValue" xml:space="preserve">
+    <value>URL must be an absolute HTTPS URL to an Azure Key Vault.</value>
+  </data>
   <data name="UrlOptionDescription" xml:space="preserve">
     <value>URL to an Azure Key Vault.</value>
   </data>

--- a/src/Sign.Cli/Helpers/HashAlgorithmParser.cs
+++ b/src/Sign.Cli/Helpers/HashAlgorithmParser.cs
@@ -31,7 +31,7 @@ namespace Sign.Cli
                     return HashAlgorithmName.SHA512;
 
                 default:
-                    result.ErrorMessage = string.Format(CultureInfo.CurrentCulture, Resources.InvalidDigestValue, $"--{result.Argument.Name}");
+                    result.AddError(string.Format(CultureInfo.CurrentCulture, Resources.InvalidDigestValue, result.Argument.Name));
 
                     return HashAlgorithmName.SHA256;
             }

--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using Sign.Core;
 
 namespace Sign.Cli
@@ -36,9 +33,9 @@ namespace Sign.Cli
 
                 try
                 {
-                    Parser parser = CreateParser();
+                    SignCommand rootCommand = CreateCommand(serviceProviderFactory: null);
 
-                    return await parser.InvokeAsync(args);
+                    return await rootCommand.Parse(args).InvokeAsync();
                 }
                 catch (Exception ex)
                 {
@@ -56,15 +53,9 @@ namespace Sign.Cli
             Console.ResetColor();
         }
 
-        internal static Parser CreateParser(IServiceProviderFactory? serviceProviderFactory = null)
+        internal static SignCommand CreateCommand(IServiceProviderFactory? serviceProviderFactory = null)
         {
-            SignCommand command = new(serviceProviderFactory);
-
-            return new CommandLineBuilder(command)
-                .UseVersionOption()
-                .UseParseErrorReporting()
-                .UseHelp()
-                .Build();
+            return new SignCommand(serviceProviderFactory);
         }
     }
 }

--- a/src/Sign.Cli/Properties/launchSettings.json
+++ b/src/Sign.Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Sign.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "code certificate-store -cf F:\\git\\Entropy\\MakeTestCert\\c6a45139645123ddfd0cab9789473d4cdd26782b.pfx -cfp 076281aa18694128ce8571fdfb37ba454fd5c8981aac1708d13c204091e1b861 -t http://timestamp.acs.microsoft.com -b F:\\git\\NuGet.Client\\artifacts\\nupkgs -o _signed.NuGet.Common.6.13.0-zlocal.32767.nupkg -m 1 -v trace -fl F:\\git\\sign\\filelist.txt *"
+      "commandLineArgs": "code certificate-store -b C:\\Trash -v trace -cf C:\\git\\Entropy\\MakeTestCert\\af994810f3d0d01b5f6f37e8be085e1a537d40c9.pfx -cfp 0695cf4875ae67f2194ea4c2cbcdcb1327c6874d5949321c4d8028bed308b7a6 MakeTestCert.dll -o MakeTestCert.signed.dll"
     }
   }
 }

--- a/src/Sign.Cli/SignCommand.cs
+++ b/src/Sign.Cli/SignCommand.cs
@@ -7,33 +7,33 @@ using Sign.Core;
 
 namespace Sign.Cli
 {
-    internal sealed class SignCommand : Command
+    internal sealed class SignCommand : RootCommand
     {
         internal SignCommand(IServiceProviderFactory? serviceProviderFactory = null)
-            : base("sign", Resources.SignCommandDescription)
+            : base(Resources.SignCommandDescription)
         {
             CodeCommand codeCommand = new();
             serviceProviderFactory ??= new ServiceProviderFactory();
 
-            AddCommand(codeCommand);
+            Subcommands.Add(codeCommand);
 
             AzureKeyVaultCommand azureKeyVaultCommand = new(
                 codeCommand,
                 serviceProviderFactory);
 
-            codeCommand.AddCommand(azureKeyVaultCommand);
+            codeCommand.Subcommands.Add(azureKeyVaultCommand);
 
             CertificateStoreCommand certificateStoreCommand = new(
                 codeCommand,
                 serviceProviderFactory);
 
-            codeCommand.AddCommand(certificateStoreCommand);
+            codeCommand.Subcommands.Add(certificateStoreCommand);
 
             TrustedSigningCommand trustedSigningCommand = new(
                 codeCommand,
                 serviceProviderFactory);
 
-            codeCommand.AddCommand(trustedSigningCommand);
+            codeCommand.Subcommands.Add(trustedSigningCommand);
         }
     }
 }

--- a/src/Sign.Cli/StandardStreamWriterExtensions.cs
+++ b/src/Sign.Cli/StandardStreamWriterExtensions.cs
@@ -2,21 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using System.CommandLine;
-using System.CommandLine.IO;
 using System.Globalization;
 
 namespace Sign.Cli
 {
     internal static class StandardStreamWriterExtensions
     {
-        internal static void WriteFormattedLine(this IStandardStreamWriter writer, string format, params IdentifierSymbol[] symbols)
+        internal static void WriteFormattedLine(this TextWriter writer, string format, params object[] options)
         {
-            string[] formattedSymbols = symbols
-                .Select(symbol => $"--{symbol.Name}")
+            string[] formattedOptions = options
+                .Select(option => $"{((dynamic)option).Name}")
                 .ToArray();
 
-            writer.WriteLine(string.Format(CultureInfo.InvariantCulture, format, formattedSymbols));
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture, format, formattedOptions));
         }
     }
 }

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Adresa URL musí obsahovat pouze protokol a hostitele. (např. https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Adresa URL Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Die URL darf nur das Protokoll und den Host enthalten. (Beispiel: https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">URL zu einem Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">La dirección URL solo debe contener el protocolo y el host. (por ejemplo: https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Dirección URL a un Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">L’URL doit contenir uniquement le protocole et l’hôte. (par exemple : https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">URL d’un Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">L'URL deve contenere solo il protocollo e l'host. (ad esempio: https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">URL a un Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">URL にはプロトコルとホストのみを含めなければなりません。(例: https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Azure Key Vault への URL。</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">URL은 프로토콜과 호스트만 포함해야 합니다. (예: https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Azure Key Vault에 대한 URL입니다.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Adres URL może zawierać tylko protokół i hosta. (np. https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Adres URL do usługi Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">A URL deve conter somente o protocolo e o host. (por exemplo: https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">URL para um Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">URL-адрес должен содержать только протокол и хост. (например, https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">URL-адрес для Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">URL yalnızca protokolü ve ana bilgisayarı içermeli. (ör. https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Azure Key Vault URL’si.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">URL 只能包含协议和主机。(，例如： https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">指向 Azure Key Vault 的 URL。</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">URL 只能包含通訊協定和主機。(例如： https://&lt;vault-name&gt;.vault.azure.net/)</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>URL must be an absolute HTTPS URL to an Azure Key Vault.</source>
+        <target state="new">URL must be an absolute HTTPS URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UrlOptionDescription">
         <source>URL to an Azure Key Vault.</source>
         <target state="translated">Azure Key Vault 的 URL。</target>

--- a/src/Sign.Core/Tools/VsixSignTool/HashAlgorithmInfo.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/HashAlgorithmInfo.cs
@@ -21,7 +21,7 @@ namespace Sign.Core
         public HashAlgorithmInfo(HashAlgorithmName name)
         {
             Name = name;
-            
+
             if (name == HashAlgorithmName.SHA256)
             {
                 XmlDSigIdentifier = OpcKnownUris.HashAlgorithms.Sha256DigestUri;

--- a/src/Sign.Core/Tools/VsixSignTool/HexHelpers.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/HexHelpers.cs
@@ -45,7 +45,7 @@ namespace Sign.Core
             {
                 var value = data[i];
                 buffer[j] = (char)LookupTable[(value & 0xF0) >> 4];
-                buffer[j+1] = (char)LookupTable[value & 0x0F];
+                buffer[j + 1] = (char)LookupTable[value & 0x0F];
             }
 
             return true;

--- a/src/Sign.Core/Tools/VsixSignTool/OpcContentTypes.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/OpcContentTypes.cs
@@ -121,7 +121,7 @@ namespace Sign.Core
         {
             XName TranslateToElementName(OpcContentTypeMode mode)
             {
-                switch(mode)
+                switch (mode)
                 {
                     case OpcContentTypeMode.Default:
                         return _opcContentTypeNamespace + "Default";
@@ -135,7 +135,7 @@ namespace Sign.Core
             var document = new XDocument();
             var root = new XElement(_opcContentTypeNamespace + "Types");
 
-            foreach(var contentType in _contentTypes)
+            foreach (OpcContentType contentType in _contentTypes)
             {
                 var element = new XElement(TranslateToElementName(contentType.Mode));
                 element.SetAttributeValue("Extension", contentType.Extension);

--- a/src/Sign.Core/Tools/VsixSignTool/OpcPackageTimestampBuilder.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/OpcPackageTimestampBuilder.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using Sign.Core.Timestamp;
 using System.Security.Cryptography;
 using System.Xml;
 using System.Xml.Linq;
+using Sign.Core.Timestamp;
 
 namespace Sign.Core
 {

--- a/src/Sign.Core/Tools/VsixSignTool/SignConfigurationSet.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/SignConfigurationSet.cs
@@ -46,6 +46,5 @@ namespace Sign.Core
         /// An <see cref="X509Certificate2"/> that contains the public key and certificate used to embed in the signature.
         /// </summary>
         public X509Certificate2 PublicCertificate { get; }
-        
     }
 }

--- a/src/Sign.Core/Tools/VsixSignTool/Timestamp/TimestampNonce.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/Timestamp/TimestampNonce.cs
@@ -19,7 +19,7 @@ namespace Sign.Core.Timestamp
         {
             var nonce = new byte[nonceSize];
 #if NET
-                RandomNumberGenerator.Fill(nonce);
+            RandomNumberGenerator.Fill(nonce);
 #else
             using (var rng = RandomNumberGenerator.Create())
             {

--- a/test/Sign.Cli.Test/CodeCommandTests.cs
+++ b/test/Sign.Cli.Test/CodeCommandTests.cs
@@ -19,7 +19,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void BaseDirectoryOption_Always_IsNotRequired()
         {
-            Assert.False(_command.BaseDirectoryOption.IsRequired);
+            Assert.False(_command.BaseDirectoryOption.Required);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void DescriptionOption_Always_IsNotRequired()
         {
-            Assert.False(_command.DescriptionOption.IsRequired);
+            Assert.False(_command.DescriptionOption.Required);
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void DescriptionUrlOption_Always_IsNotRequired()
         {
-            Assert.False(_command.DescriptionUrlOption.IsRequired);
+            Assert.False(_command.DescriptionUrlOption.Required);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void FileDigestOption_Always_IsNotRequired()
         {
-            Assert.False(_command.FileDigestOption.IsRequired);
+            Assert.False(_command.FileDigestOption.Required);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void FileListOption_Always_IsNotRequired()
         {
-            Assert.False(_command.FileListOption.IsRequired);
+            Assert.False(_command.FileListOption.Required);
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void MaxConcurrencyOption_Always_IsNotRequired()
         {
-            Assert.False(_command.MaxConcurrencyOption.IsRequired);
+            Assert.False(_command.MaxConcurrencyOption.Required);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void OutputOption_Always_IsNotRequired()
         {
-            Assert.False(_command.OutputOption.IsRequired);
+            Assert.False(_command.OutputOption.Required);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void PublisherNameOption_Always_IsNotRequired()
         {
-            Assert.False(_command.PublisherNameOption.IsRequired);
+            Assert.False(_command.PublisherNameOption.Required);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void TimestampDigestOption_Always_IsNotRequired()
         {
-            Assert.False(_command.TimestampDigestOption.IsRequired);
+            Assert.False(_command.TimestampDigestOption.Required);
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void TimestampUrlOption_Always_IsNotRequired()
         {
-            Assert.False(_command.TimestampUrlOption.IsRequired);
+            Assert.False(_command.TimestampUrlOption.Required);
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void VerbosityOption_Always_IsNotRequired()
         {
-            Assert.False(_command.VerbosityOption.IsRequired);
+            Assert.False(_command.VerbosityOption.Required);
         }
     }
 }

--- a/test/Sign.Cli.Test/Options/BaseDirectoryOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/BaseDirectoryOptionTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using System.CommandLine.Parsing;
+using System.CommandLine;
 using System.Globalization;
 
 namespace Sign.Cli.Test
@@ -18,7 +18,7 @@ namespace Sign.Cli.Test
         public void Option_WhenOptionIsMissing_HasDefaultValue()
         {
             ParseResult result = Parse();
-            DirectoryInfo? value = result.GetValueForOption(Option);
+            DirectoryInfo? value = result.GetValue(Option);
 
             VerifyEqual(new DirectoryInfo(Environment.CurrentDirectory), value);
         }

--- a/test/Sign.Cli.Test/Options/HashAlgorithmNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/HashAlgorithmNameOptionTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.Security.Cryptography;
 
 namespace Sign.Cli.Test
@@ -56,7 +55,7 @@ namespace Sign.Cli.Test
         public void Option_WhenOptionIsMissing_HasDefaultValue()
         {
             ParseResult result = Parse();
-            HashAlgorithmName value = result.GetValueForOption(Option);
+            HashAlgorithmName value = result.GetValue(Option);
 
             Assert.Equal(HashAlgorithmName.SHA256, value);
         }

--- a/test/Sign.Cli.Test/Options/MaxConcurrencyOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/MaxConcurrencyOptionTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using System.CommandLine.Parsing;
+using System.CommandLine;
 
 namespace Sign.Cli.Test
 {
@@ -25,7 +25,7 @@ namespace Sign.Cli.Test
         public void Option_WhenOptionIsMissing_HasDefaultValue()
         {
             ParseResult result = Parse();
-            int value = result.GetValueForOption(Option);
+            int value = result.GetValue(Option);
 
             Assert.Equal(4, value);
         }

--- a/test/Sign.Cli.Test/Options/OptionTests.cs
+++ b/test/Sign.Cli.Test/Options/OptionTests.cs
@@ -35,11 +35,11 @@ namespace Sign.Cli.Test
         {
             const string value = "x";
 
-            if (Option.IsRequired)
+            if (Option.Required)
             {
                 VerifyHasErrors(
                     value,
-                    GetOptionIsRequiredMessage(ShortOption),
+                    GetOptionRequiredMessage(ShortOption),
                     GetUnrecognizedCommandOrArgumentMessage(value));
             }
             else
@@ -101,7 +101,7 @@ namespace Sign.Cli.Test
 
             Assert.Empty(result.Errors);
 
-            T? actualValue = result.GetValueForOption(Option);
+            T? actualValue = result.GetValue(Option);
 
             VerifyEqual(expectedValue, actualValue);
         }
@@ -127,11 +127,11 @@ namespace Sign.Cli.Test
         {
             ParseResult result = Parse();
 
-            if (Option.IsRequired)
+            if (Option.Required)
             {
                 ParseError parseError = Assert.Single(result.Errors);
                 string actualMessage = parseError.Message;
-                string expectedMessage = GetOptionIsRequiredMessage(ShortOption);
+                string expectedMessage = GetOptionRequiredMessage(ShortOption);
 
                 Assert.Equal(expectedMessage, actualMessage);
             }
@@ -161,7 +161,7 @@ namespace Sign.Cli.Test
                 argumentName);
         }
 
-        protected static string GetOptionIsRequiredMessage(string optionName)
+        protected static string GetOptionRequiredMessage(string optionName)
         {
             return string.Format(
                 CultureInfo.CurrentCulture,

--- a/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using System.CommandLine.Parsing;
+using System.CommandLine;
 
 namespace Sign.Cli.Test
 {
@@ -17,7 +17,7 @@ namespace Sign.Cli.Test
         public void Option_WhenOptionIsMissing_HasDefaultValue()
         {
             ParseResult result = Parse();
-            Uri? value = result.GetValueForOption(Option);
+            Uri? value = result.GetValue(Option);
 
             Assert.NotNull(value);
             Assert.Equal("http://timestamp.acs.microsoft.com/", value.AbsoluteUri);

--- a/test/Sign.Cli.Test/Options/UriOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/UriOptionTests.cs
@@ -20,11 +20,11 @@ namespace Sign.Cli.Test
         {
             const string value = "3";
 
-            if (Option.IsRequired)
+            if (Option.Required)
             {
                 VerifyHasErrors(
                     value,
-                    GetOptionIsRequiredMessage(ShortOption),
+                    GetOptionRequiredMessage(ShortOption),
                     GetUnrecognizedCommandOrArgumentMessage(value));
             }
             else

--- a/test/Sign.Cli.Test/SignCommandTests.cs
+++ b/test/Sign.Cli.Test/SignCommandTests.cs
@@ -16,25 +16,23 @@ namespace Sign.Cli.Test
         private const string TimestampUrl = "http://timestamp.test";
         private const string File = "c";
 
-        private readonly Parser _parser;
+        private readonly SignCommand _signCommand;
         private readonly CodeCommand _codeCommand;
         private readonly AzureKeyVaultCommand _azureKeyVaultCommand;
 
         public SignCommandTests()
         {
-            _parser = Program.CreateParser();
+            _signCommand = Program.CreateCommand();
 
-            SignCommand? signCommand = _parser.Configuration.RootCommand as SignCommand;
+            Assert.NotNull(_signCommand);
 
-            Assert.NotNull(signCommand);
-
-            CodeCommand? codeCommand = signCommand.Children
+            CodeCommand? codeCommand = _signCommand.Subcommands
                 .Where(child => child is CodeCommand)
                 .Single() as CodeCommand;
 
             Assert.NotNull(codeCommand);
 
-            AzureKeyVaultCommand? azureKeyVaultCommand = codeCommand.Children
+            AzureKeyVaultCommand? azureKeyVaultCommand = codeCommand.Subcommands
                 .Where(child => child is AzureKeyVaultCommand)
                 .Single() as AzureKeyVaultCommand;
 
@@ -47,14 +45,14 @@ namespace Sign.Cli.Test
         [Fact]
         public void Help_Always_IsEnabled()
         {
-            ParseResult result = _parser.Parse("-?");
-            Symbol symbol = result.CommandResult.Children.Single().Symbol;
-            Option? option = symbol as Option;
+            ParseResult result = _signCommand.Parse("-?");
+            SymbolResult symbolResult = result.CommandResult.Children.Single();
+            OptionResult? optionResult = symbolResult as OptionResult;
 
-            Assert.NotNull(option);
+            Assert.NotNull(optionResult);
 
-            string[] expectedAliases = new[] { "--help", "-?", "-h", "/?", "/h" };
-            string[] actualAliases = option.Aliases.OrderBy(_ => _, StringComparer.Ordinal).ToArray();
+            string[] expectedAliases = new[] { "-?", "-h", "/?", "/h" };
+            string[] actualAliases = optionResult.Option.Aliases.OrderBy(_ => _, StringComparer.Ordinal).ToArray();
 
             Assert.Equal(expectedAliases, actualAliases);
             Assert.Empty(result.Errors);
@@ -65,16 +63,16 @@ namespace Sign.Cli.Test
         [InlineData("code azure-key-vault")]
         public void Command_WhenArgumentAndOptionsAreMissing_HasError(string command)
         {
-            ParseResult result = _parser.Parse(command);
+            ParseResult result = _signCommand.Parse(command);
             Assert.NotEmpty(result.Errors);
         }
 
         [Fact]
         public void Command_WhenRequiredArgumentIsMissing_HasError()
         {
-            string command = $"code azure-key-vault --description {Description} --description-url {DescriptionUrl} "
-                + $"-kvu {KeyVaultUrl} -kvc {CertificateName} --timestamp-url {TimestampUrl}";
-            ParseResult result = _parser.Parse(command);
+            string command = $"code --description {Description} --description-url {DescriptionUrl} --timestamp-url {TimestampUrl} "
+                + $"azure-key-vault -kvu {KeyVaultUrl} -kvc {CertificateName}";
+            ParseResult result = _signCommand.Parse(command);
 
             Assert.NotEmpty(result.Errors);
         }
@@ -82,18 +80,18 @@ namespace Sign.Cli.Test
         [Fact]
         public void Command_WhenAllOptionsAndArgumentAreValid_HasNoError()
         {
-            string command = $"code azure-key-vault --description {Description} --description-url {DescriptionUrl} "
-                + $"-kvu {KeyVaultUrl} -kvc {CertificateName} --timestamp-url {TimestampUrl} {File}";
-            ParseResult result = _parser.Parse(command);
+            string command = $"code --description {Description} --description-url {DescriptionUrl} --timestamp-url {TimestampUrl} "
+                + $"azure-key-vault -kvu {KeyVaultUrl} -kvc {CertificateName} {File}";
+            ParseResult result = _signCommand.Parse(command);
 
             Assert.Empty(result.Errors);
 
-            Assert.Equal(Description, result.GetValueForOption(_codeCommand.DescriptionOption));
-            Assert.Equal(DescriptionUrl, result.GetValueForOption(_codeCommand.DescriptionUrlOption)!.OriginalString);
-            Assert.Equal(KeyVaultUrl, result.GetValueForOption(_azureKeyVaultCommand.UrlOption)!.OriginalString);
-            Assert.Equal(CertificateName, result.GetValueForOption(_azureKeyVaultCommand.CertificateOption));
-            Assert.Equal(TimestampUrl, result.GetValueForOption(_codeCommand.TimestampUrlOption)!.OriginalString);
-            Assert.Equal([File], result.GetValueForArgument(_azureKeyVaultCommand.FilesArgument));
+            Assert.Equal(Description, result.GetValue(_codeCommand.DescriptionOption));
+            Assert.Equal(DescriptionUrl, result.GetValue(_codeCommand.DescriptionUrlOption)!.OriginalString);
+            Assert.Equal(KeyVaultUrl, result.GetValue(_azureKeyVaultCommand.UrlOption)!.OriginalString);
+            Assert.Equal(CertificateName, result.GetValue(_azureKeyVaultCommand.CertificateOption));
+            Assert.Equal(TimestampUrl, result.GetValue(_codeCommand.TimestampUrlOption)!.OriginalString);
+            Assert.Equal([File], result.GetValue(_azureKeyVaultCommand.FilesArgument));
         }
     }
 }

--- a/test/Sign.Cli.Test/TrustedSigningCommandTests.cs
+++ b/test/Sign.Cli.Test/TrustedSigningCommandTests.cs
@@ -3,8 +3,6 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using Moq;
 using Sign.Core;
 
@@ -41,7 +39,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void EndpointOption_Always_IsRequired()
         {
-            Assert.True(_command.EndpointOption.IsRequired);
+            Assert.True(_command.EndpointOption.Required);
         }
 
         [Fact]
@@ -53,7 +51,7 @@ namespace Sign.Cli.Test
         [Fact]
         public void AccountOption_Always_IsRequired()
         {
-            Assert.True(_command.AccountOption.IsRequired);
+            Assert.True(_command.AccountOption.Required);
         }
 
         [Fact]
@@ -65,47 +63,50 @@ namespace Sign.Cli.Test
         [Fact]
         public void CertificateProfileOption_Always_IsRequired()
         {
-            Assert.True(_command.CertificateProfileOption.IsRequired);
+            Assert.True(_command.CertificateProfileOption.Required);
         }
 
         public class ParserTests
         {
             private readonly TrustedSigningCommand _command;
-            private readonly Parser _parser;
+            private readonly RootCommand _rootCommand;
 
             public ParserTests()
             {
-                _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
-                _parser = new CommandLineBuilder(_command).Build();
+                CodeCommand codeCommand = new();
+                _command = new(codeCommand, Mock.Of<IServiceProviderFactory>());
+                _rootCommand = new RootCommand();
+                _rootCommand.Subcommands.Add(codeCommand);
+                codeCommand.Subcommands.Add(_command);
             }
 
             [Theory]
-            [InlineData("trusted-signing")]
-            [InlineData("trusted-signing a")]
-            [InlineData("trusted-signing -tse")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d -kvs")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d -kvs e")]
+            [InlineData("code trusted-signing")]
+            [InlineData("code trusted-signing a")]
+            [InlineData("code trusted-signing -tse")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d -kvs")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d -kvs e")]
             public void Command_WhenRequiredArgumentOrOptionsAreMissing_HasError(string command)
             {
-                ParseResult result = _parser.Parse(command);
+                ParseResult result = _rootCommand.Parse(command);
 
                 Assert.NotEmpty(result.Errors);
             }
 
             [Theory]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b c")]
-            [InlineData("trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d -kvs e f")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b c")]
+            [InlineData("code trusted-signing -tse https://trustedsigning.test -tsa a -tscp b -kvt c -kvi d -kvs e f")]
             public void Command_WhenRequiredArgumentsArePresent_HasNoError(string command)
             {
-                ParseResult result = _parser.Parse(command);
+                ParseResult result = _rootCommand.Parse(command);
 
                 Assert.Empty(result.Errors);
             }

--- a/test/Sign.Core.Test/TestInfrastructure/Server/SigningTestsCollection.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/SigningTestsCollection.cs
@@ -6,7 +6,7 @@ using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
 {
-    [CollectionDefinition(Name)]
+    [CollectionDefinition(Name, DisableParallelization = true)]
     public sealed class SigningTestsCollection :
         ICollectionFixture<CertificatesFixture>,
         ICollectionFixture<TrustedCertificateFixture>,

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Azure;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Sign.TestInfrastructure;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Sign.SignatureProviders.KeyVault.Test
 {

--- a/test/Sign.SignatureProviders.TrustedSigning.Test/RSATrustedSigningTests.cs
+++ b/test/Sign.SignatureProviders.TrustedSigning.Test/RSATrustedSigningTests.cs
@@ -158,7 +158,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
                 .Setup(_ => _.WaitForCompletion(default))
                 .Returns(response.Object);
 
-            _client.Setup(_ => _.StartSign(AccountName, CertificateProfileName, It.IsAny<SignRequest>(), null, null, default))
+            _client.Setup(_ => _.StartSign(AccountName, CertificateProfileName, It.IsAny<SignRequest>(), null, null, null, default))
                     .Returns(operation.Object);
 
             var result = rsa.SignHash(hash, hashAlgorithmName, padding);
@@ -169,6 +169,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
                 AccountName,
                 CertificateProfileName,
                 It.Is<SignRequest>(request => request.SignatureAlgorithm == expectedSignatureAlgorithm && ReferenceEquals(request.Digest, hash)),
+                null,
                 null,
                 null,
                 default), Times.Once());


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/958

There were many breaking changes between System.CommandLine 2.0.0-beta4.22272.1 and 2.0.0.  These changes:

* Update to use System.CommandLine 2.0.0 API's.
* System.CommandLine used to support `Uri` options, but 2.0.0 does not. Add a custom URL parser for the Azure Key Vault URL option to ensure that only absolute HTTPS URL's are accepted.
* Fix a subtle bug that may have prevented exit codes from propagating correctly. See https://github.com/dotnet/command-line-api/issues/2562 for details.
* Disable test parallelization on `SigningTestsCollection` to fix test failures.
* Make minor formatting and style changes.