### PR TITLE
Fix URL parsing for '--trusted-signing-endpoint'

### DIFF
--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -310,7 +310,7 @@ namespace Sign.Cli
             return value;
         }
 
-        private static Uri? ParseUrl(ArgumentResult result)
+        internal static Uri? ParseUrl(ArgumentResult result)
         {
             if (result.Tokens.Count != 1 ||
                 !Uri.TryCreate(result.Tokens[0].Value, UriKind.Absolute, out Uri? uri) ||

--- a/src/Sign.Cli/TrustedSigningCommand.cs
+++ b/src/Sign.Cli/TrustedSigningCommand.cs
@@ -31,6 +31,7 @@ namespace Sign.Cli
 
             EndpointOption = new Option<Uri>("--trusted-signing-endpoint", "-tse")
             {
+                CustomParser = CodeCommand.ParseUrl,
                 Description = TrustedSigningResources.EndpointOptionDescription,
                 Required = true
             };


### PR DESCRIPTION
Fixes #965.

I didn't see an obvious "Utility" class to move `ParseUrl` to, so I just reused it from `CodeCommand`.