### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,30 +10,27 @@
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-    <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
+    <PackageVersion Include="AzureSign.Core" Version="7.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.9" />
     <PackageVersion Include="Microsoft.Dynamics.BusinessCentral.Sip.Main" Version="24.0.15760" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <!-- Lift this dependency to enable Sign.Core.Test override the version. -->
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7463" />
     <!-- We're staying on 4.18.4 until we migrate to another mocking framework.
          See https://github.com/dotnet/runtime/issues/90222 and https://github.com/devlooped/moq/issues/1374
          for context.   -->
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="NuGet.Packaging" Version="7.0.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.2" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.2" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/test/Sign.Core.Test/Sign.Core.Test.csproj
+++ b/test/Sign.Core.Test/Sign.Core.Test.csproj
@@ -14,10 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <!-- Add an explicit reference to updated Kestrel.Core package version to bring in fix for CVE-2025-55315 -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
-    <!-- Microsoft.AspNetCore.Server.Kestrel is old and requires an older version of Microsoft.Extensions.Primitives to function. -->
-    <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="2.2.0" />
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/974

We were referencing a 2018 version of Microsoft.AspNetCore.Server.Kestrel.* packages.  With this change, we're updating to recent (2026) package versions.  This update eliminates the need for version overriding in Sign.Core.Test.csproj, so I removed it.