### PR TITLE
Revert "Update pipeline (#976)"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -38,7 +38,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      networkIsolationPolicy: Preferred,CFSClean,CFSClean2
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)


### PR DESCRIPTION
This reverts commit 8fac312ed86894f7aa67fd64ba605876c7ea0e32.

The internal CI build failed because OneLocBuild task is blocked by the `Preferred` policy.  Reverting to the `Permissive` policy.