### PR TITLE
Fix tool package

### DIFF
--- a/SdkTools.props
+++ b/SdkTools.props
@@ -46,17 +46,17 @@
   <ItemGroup>
     <Content Include="@(SdkFile64)" Exclude="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\wintrust.dll.ini">
       <Pack>true</Pack>
-      <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x64</PackagePath>
+      <PackagePath>tools\$(TargetFramework)\$(RuntimeIdentifier)\tools\SDK\x64</PackagePath>
       <Visible>false</Visible>
     </Content>
     <Content Include="$(OutputPath)\tools\SDK\x64\wintrust.dll.ini">
       <Pack>true</Pack>
-      <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x64</PackagePath>
+      <PackagePath>tools\$(TargetFramework)\$(RuntimeIdentifier)\tools\SDK\x64</PackagePath>
       <Visible>false</Visible>
     </Content>
     <Content Include="@(SdkFile86)">
       <Pack>true</Pack>
-      <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x86</PackagePath>
+      <PackagePath>tools\$(TargetFramework)\$(RuntimeIdentifier)\tools\SDK\x86</PackagePath>
       <Visible>false</Visible>
     </Content>
   </ItemGroup>

--- a/scripts/VerifyNuGetPackage.ps1
+++ b/scripts/VerifyNuGetPackage.ps1
@@ -61,22 +61,23 @@ If ($packageFilePaths.Count -ne 1)
 [System.IO.File]::Copy($sourcePackageFilePath, $destinationFile.FullName, $overwrite)
 
 [string[]] $expectedEntryFullNames =
-    'tools/net8.0/any/tools/SDK/x64/appxpackaging.dll',
-    'tools/net8.0/any/tools/SDK/x64/appxsip.dll',
-    'tools/net8.0/any/tools/SDK/x64/makeappx.exe',
-    'tools/net8.0/any/tools/SDK/x64/makepri.exe',
-    'tools/net8.0/any/tools/SDK/x64/Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest',
-    'tools/net8.0/any/tools/SDK/x64/Microsoft.Windows.Build.Appx.AppxSip.dll.manifest',
-    'tools/net8.0/any/tools/SDK/x64/Microsoft.Windows.Build.Appx.OpcServices.dll.manifest',
-    'tools/net8.0/any/tools/SDK/x64/Microsoft.Windows.Build.Signing.mssign32.dll.manifest',
-    'tools/net8.0/any/tools/SDK/x64/Microsoft.Windows.Build.Signing.wintrust.dll.manifest',
-    'tools/net8.0/any/tools/SDK/x64/mssign32.dll',
-    'tools/net8.0/any/tools/SDK/x64/NavSip.dll',
-    'tools/net8.0/any/tools/SDK/x64/opcservices.dll',
-    'tools/net8.0/any/tools/SDK/x64/SignTool.exe.manifest',
-    'tools/net8.0/any/tools/SDK/x64/wintrust.dll',
-    'tools/net8.0/any/tools/SDK/x64/wintrust.dll.ini',
-    'tools/net8.0/any/tools/SDK/x86/mage.exe'
+    'tools/net8.0/win-x64/sign.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/appxpackaging.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/appxsip.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/makeappx.exe',
+    'tools/net8.0/win-x64/tools/SDK/x64/makepri.exe',
+    'tools/net8.0/win-x64/tools/SDK/x64/Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest',
+    'tools/net8.0/win-x64/tools/SDK/x64/Microsoft.Windows.Build.Appx.AppxSip.dll.manifest',
+    'tools/net8.0/win-x64/tools/SDK/x64/Microsoft.Windows.Build.Appx.OpcServices.dll.manifest',
+    'tools/net8.0/win-x64/tools/SDK/x64/Microsoft.Windows.Build.Signing.mssign32.dll.manifest',
+    'tools/net8.0/win-x64/tools/SDK/x64/Microsoft.Windows.Build.Signing.wintrust.dll.manifest',
+    'tools/net8.0/win-x64/tools/SDK/x64/mssign32.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/NavSip.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/opcservices.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/SignTool.exe.manifest',
+    'tools/net8.0/win-x64/tools/SDK/x64/wintrust.dll',
+    'tools/net8.0/win-x64/tools/SDK/x64/wintrust.dll.ini',
+    'tools/net8.0/win-x64/tools/SDK/x86/mage.exe'
 
 Try
 {


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/978

A breaking change in .NET 10 SDK is that [.NET tool packages are now RID-specific](https://learn.microsoft.com/dotnet/core/compatibility/sdk/10.0/dotnet-tool-pack-publish).  As a result, primary assets within the package are now under a `win-x64` folder instead of an `any` folder.  However, the build still put Windows SDK tools under the `any` folder.  As a result, at runtime this tool (under `win-x64`) could not find Windows SDK tool files in a `tools` subdirectory.

The fix is to put the Windows SDK tools under the `win-x64` folder instead of the `any` folder.

This is a packaging-specific regression.  As part of the build, a package verification script verifies that Windows SDK tools are in the expected location succeeded because it continued verifying the old location:  the `any` folder.

This change also updates the verification script to look for both sign.dll and Windows SDK tools in the `win-x64` folder.
