### PR TITLE
Add primer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,5 @@ ECDSA is not supported.  Not only do some signature providers not support ECDSA,
 
 ## Useful Links
 
+* [Sign CLI Primer](docs/primer.md) (for maintainers: cryptography vocabulary, signature-format details)
 * [Issue Triage Policy](triage-policy.md)

--- a/docs/images/structures-signedcms.svg
+++ b/docs/images/structures-signedcms.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 860" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="12">
+  <style>
+    :root { color-scheme: light dark; }
+
+    .title  { font-size: 16px; font-weight: 700; fill: #1f2937; }
+    .sub    { font-size: 11px; font-style: italic; fill: #4b5563; }
+    .h      { font-size: 14px; font-weight: 700; fill: #1f2937; }
+    .key    { font-size: 13px; font-weight: 600; fill: #111827; }
+    .ann    { font-size: 11px; font-style: italic; fill: #4b5563; }
+    .mono   { font-family: Consolas, "Courier New", monospace; font-size: 12px; fill: #111827; }
+    .desc   { font-size: 12px; fill: #4b5563; }
+
+    .outer  { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.5; }
+    .group  { fill: #ffffff; stroke: #6b7280; stroke-width: 1; }
+    .nested { fill: #fef3c7; stroke: #b45309; stroke-width: 1; }
+    .leaf   { fill: #ecfdf5; stroke: #047857; stroke-width: 1; }
+
+    @media (prefers-color-scheme: dark) {
+      .title, .h           { fill: #f3f4f6; }
+      .sub, .ann           { fill: #9ca3af; }
+      .key, .mono          { fill: #e5e7eb; }
+      .desc                { fill: #9ca3af; }
+
+      .outer  { fill: #1e1b4b; stroke: #818cf8; }
+      .group  { fill: #111827; stroke: #9ca3af; }
+      .nested { fill: #422006; stroke: #fbbf24; }
+      .leaf   { fill: #022c22; stroke: #34d399; }
+    }
+  </style>
+
+  <text class="title" x="12" y="22">SignedCms (CMS SignedData, RFC 5652)</text>
+  <text class="sub"   x="12" y="44">ASN.1 / DER. Carries the signature plus everything needed to verify it.</text>
+
+  <rect class="outer" x="12" y="60" width="576" height="786" rx="6"/>
+  <text class="h"    x="28" y="82">ContentInfo</text>
+  <text class="mono" x="28" y="106">contentType</text>
+  <text class="desc" x="170" y="106">= 1.2.840.113549.1.7.2 (signedData)</text>
+
+  <rect class="group" x="28" y="122" width="544" height="716" rx="4"/>
+  <text class="h"    x="44" y="144">SignedData</text>
+  <text class="mono" x="44" y="170">version</text>
+  <text class="mono" x="44" y="192">digestAlgorithms</text>
+  <text class="desc" x="168" y="192">set of algorithms used by signers (e.g. SHA-256)</text>
+
+  <rect class="nested" x="44" y="208" width="512" height="98" rx="4"/>
+  <text class="key"  x="58" y="228">encapContentInfo</text>
+  <text class="mono" x="58" y="254">eContentType</text>
+  <text class="desc" x="158" y="254">(e.g. SPC_INDIRECT_DATA for Authenticode, id-data for NuGet)</text>
+  <text class="mono" x="58" y="278">eContent</text>
+  <text class="desc" x="158" y="278">the thing whose digest is signed; may be detached</text>
+
+  <rect class="nested" x="44" y="322" width="512" height="72" rx="4"/>
+  <text class="key"  x="58" y="342">certificates [0..n]</text>
+  <text class="desc" x="58" y="368">X.509 chain: signer leaf → intermediates (root usually omitted)</text>
+
+  <rect class="nested" x="44" y="410" width="512" height="46" rx="4"/>
+  <text class="key" x="58" y="432">crls [0..n]</text>
+  <text class="ann" x="140" y="432">(rarely embedded; usually fetched live)</text>
+
+  <rect class="nested" x="44" y="472" width="512" height="360" rx="4"/>
+  <text class="key" x="58" y="492">signerInfos [0..n]   SignerInfo</text>
+
+  <rect class="leaf" x="60" y="506" width="480" height="316" rx="4"/>
+  <text class="mono" x="74" y="526">sid</text>
+  <text class="desc" x="220" y="526">issuerAndSerialNumber OR SubjectKeyIdentifier</text>
+  <text class="mono" x="74" y="548">digestAlgorithm</text>
+  <text class="desc" x="220" y="548">(e.g. SHA-256, SHA-384, SHA-512)</text>
+
+  <text class="key"  x="74" y="576">signedAttrs (authenticated)</text>
+  <text class="mono" x="88" y="598">content-type</text>
+  <text class="desc" x="220" y="598">1.2.840.113549.1.9.3</text>
+  <text class="mono" x="88" y="620">message-digest</text>
+  <text class="desc" x="220" y="620">1.2.840.113549.1.9.4 (hash of eContent)</text>
+  <text class="mono" x="88" y="642">signing-time</text>
+  <text class="desc" x="220" y="642">1.2.840.113549.1.9.5</text>
+  <text class="mono" x="88" y="664">signing-cert-v2 / commitment-type / ...</text>
+
+  <text class="mono" x="74" y="692">signatureAlgorithm</text>
+  <text class="desc" x="220" y="692">(e.g. RSA, RSASSA-PSS, ECDSA)</text>
+  <text class="mono" x="74" y="714">signature</text>
+  <text class="desc" x="220" y="714">Sign(privKey, hash(DER(signedAttrs)))</text>
+
+  <text class="key"  x="74" y="742">unsignedAttrs</text>
+  <text class="mono" x="88" y="764">countersignature</text>
+  <text class="desc" x="220" y="764">1.2.840.113549.1.9.6 — value: SignerInfo</text>
+  <text class="mono" x="88" y="786">timestamp (RFC 3161)</text>
+  <text class="desc" x="220" y="786">1.2.840.113549.1.9.16.2.14 — value: nested SignedData</text>
+  <text class="ann"  x="74" y="812">Anything in unsignedAttrs is NOT covered by the signature.</text>
+</svg>

--- a/docs/images/structures-x509.svg
+++ b/docs/images/structures-x509.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 778" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="12">
+  <style>
+    :root { color-scheme: light dark; }
+
+    .title  { font-size: 16px; font-weight: 700; fill: #1f2937; }
+    .sub    { font-size: 11px; font-style: italic; fill: #4b5563; }
+    .h      { font-size: 14px; font-weight: 700; fill: #1f2937; }
+    .key    { font-size: 13px; font-weight: 600; fill: #111827; }
+    .ann    { font-size: 11px; font-style: italic; fill: #4b5563; }
+    .mono   { font-family: Consolas, "Courier New", monospace; font-size: 12px; fill: #111827; }
+    .desc   { font-size: 12px; fill: #4b5563; }
+
+    .outer  { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.5; }
+    .group  { fill: #ffffff; stroke: #6b7280; stroke-width: 1; }
+    .nested { fill: #fef3c7; stroke: #b45309; stroke-width: 1; }
+    .leaf   { fill: #ecfdf5; stroke: #047857; stroke-width: 1; }
+
+    @media (prefers-color-scheme: dark) {
+      .title, .h           { fill: #f3f4f6; }
+      .sub, .ann           { fill: #9ca3af; }
+      .key, .mono          { fill: #e5e7eb; }
+      .desc                { fill: #9ca3af; }
+
+      .outer  { fill: #1e1b4b; stroke: #818cf8; }
+      .group  { fill: #111827; stroke: #9ca3af; }
+      .nested { fill: #422006; stroke: #fbbf24; }
+      .leaf   { fill: #022c22; stroke: #34d399; }
+    }
+  </style>
+
+  <text class="title" x="12" y="22">X.509 Certificate (RFC 5280)</text>
+  <text class="sub"   x="12" y="44">One entry in SignedData.certificates. Binds a public key to an identity.</text>
+
+  <rect class="outer" x="12" y="60" width="576" height="700" rx="6"/>
+  <text class="h" x="28" y="82">Certificate</text>
+
+  <rect class="group" x="28" y="98" width="544" height="558" rx="4"/>
+  <text class="h"    x="44" y="120">tbsCertificate  (to be signed)</text>
+  <text class="mono" x="44" y="146">version</text>
+  <text class="desc" x="188" y="146">v3</text>
+  <text class="mono" x="44" y="168">serialNumber</text>
+  <text class="desc" x="188" y="168">unique per issuer</text>
+  <text class="mono" x="44" y="190">signature</text>
+  <text class="desc" x="188" y="190">algorithm identifier (must match outer signatureAlgorithm)</text>
+  <text class="mono" x="44" y="212">issuer</text>
+  <text class="desc" x="188" y="212">DN of issuing CA</text>
+
+  <rect class="nested" x="44" y="228" width="512" height="68" rx="4"/>
+  <text class="key"  x="58" y="248">validity</text>
+  <text class="mono" x="58" y="272">notBefore / notAfter</text>
+  <text class="desc" x="220" y="272">(timestamps extend signature validity)</text>
+
+  <text class="mono" x="44" y="316">subject</text>
+  <text class="desc" x="188" y="316">DN of the certificate holder (e.g. CN=Contoso)</text>
+
+  <rect class="nested" x="44" y="332" width="512" height="68" rx="4"/>
+  <text class="key"  x="58" y="352">subjectPublicKeyInfo</text>
+  <text class="desc" x="58" y="376">algorithm + the public key bits (e.g. RSA 3072)</text>
+
+  <rect class="nested" x="44" y="416" width="512" height="230" rx="4"/>
+  <text class="key" x="58" y="436">extensions</text>
+
+  <rect class="leaf" x="60" y="450" width="480" height="186" rx="4"/>
+  <text class="mono" x="74" y="470">BasicConstraints</text>
+  <text class="desc" x="248" y="470">cA=FALSE for end-entity</text>
+  <text class="mono" x="74" y="492">KeyUsage</text>
+  <text class="desc" x="248" y="492">digitalSignature</text>
+  <text class="mono" x="74" y="514">ExtendedKeyUsage</text>
+  <text class="desc" x="248" y="514">(e.g. 1.3.6.1.5.5.7.3.3, codeSigning)</text>
+  <text class="mono" x="74" y="536">SubjectKeyIdentifier</text>
+  <text class="desc" x="248" y="536">SHA-1 of subject public key (typical)</text>
+  <text class="mono" x="74" y="558">AuthorityKeyIdentifier</text>
+  <text class="desc" x="248" y="558">issuer's SKI (or issuer DN + serial)</text>
+  <text class="mono" x="74" y="580">CRLDistributionPoints</text>
+  <text class="desc" x="248" y="580">where to fetch revocation info</text>
+  <text class="mono" x="74" y="602">AuthorityInfoAccess</text>
+  <text class="desc" x="248" y="602">OCSP / CA Issuers URLs</text>
+  <text class="ann"  x="74" y="626">Unknown critical extensions MUST cause verification failure.</text>
+
+  <rect class="group" x="28" y="668" width="544" height="80" rx="4"/>
+  <text class="h"    x="44" y="690">CA signature over tbsCertificate</text>
+  <text class="mono" x="44" y="716">signatureAlgorithm</text>
+  <text class="desc" x="188" y="716">(e.g. 1.2.840.113549.1.1.11, sha256WithRSAEncryption)</text>
+  <text class="mono" x="44" y="738">signatureValue</text>
+  <text class="desc" x="188" y="738">issuer's signature (verifiable with issuer's public key)</text>
+</svg>

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -1,0 +1,50 @@
+# Sign CLI Primer
+
+A companion to the [dotnet/sign README](https://github.com/dotnet/sign#readme) for engineers maintaining Sign CLI. Read the README first. This document only covers what the README does not: the cryptographic vocabulary you'll see in the code and pointers to authoritative specs.
+
+## Cryptography vocabulary
+
+- **Digest (hash)**: fixed-size fingerprint produced by a cryptographic hash algorithm (e.g. SHA-256). Spec: [NIST FIPS 180-4](https://csrc.nist.gov/publications/detail/fips/180/4/final).
+- **ASN.1 / DER**: schema (ASN.1) and deterministic byte encoding (DER) underneath certificates and signed messages. Inspect with `certutil -asn -v`. Spec: [ITU-T X.690](https://www.itu.int/rec/T-REC-X.690).
+- **OID (Object Identifier)**: dotted-number ASN.1 identifier for algorithms, certificate extensions, key usages, and signed attributes (for example `2.16.840.1.101.3.4.2.1` is SHA-256). Look up either direction with `certutil -oid <oid-or-name>`.
+- **X.509 certificate**: public key plus identity metadata, issued by a CA. Primer: [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280).
+- **CA (Certificate Authority)**: an entity that issues X.509 certificates. A root CA is self-signed and explicitly trusted by the operating system's trust store. An intermediate CA is issued by a root (or another intermediate) and issues end-entity certificates. Code-signing certificates are end-entity certificates.
+- **Certificate chain**: an ordered sequence of certificates from the end-entity (leaf) through zero or more intermediates up to a trusted root. Verifiers build the chain to confirm the leaf's issuer is trusted. CMS `SignedData` typically embeds the chain (minus the root) so verifiers can build it without fetching certificates separately.
+- **Revocation (CRL / OCSP)**: mechanisms for a CA to declare a certificate invalid before its `notAfter` date. A CRL (Certificate Revocation List) is a signed list of revoked serial numbers, fetched from a URL in the certificate's `CRLDistributionPoints` extension. OCSP (Online Certificate Status Protocol) provides real-time single-certificate status checks via the `AuthorityInfoAccess` extension. Specs: [RFC 5280 §5](https://datatracker.ietf.org/doc/html/rfc5280#section-5) (CRL), [RFC 6960](https://datatracker.ietf.org/doc/html/rfc6960) (OCSP).
+- **EKU (Extended Key Usage)**: X.509 extension constraining certificate use. Code signing is `1.3.6.1.5.5.7.3.3`. Microsoft tooling calls the same extension *Enhanced Key Usage*. Reference: [RFC 5280 §4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12).
+- **RSA**: an asymmetric signature algorithm. The holder of the private key signs a digest; anyone with the matching public key (in an X.509 certificate) can verify. Common code-signing key sizes are 3072 and 4096 bits. Sign CLI uses PKCS #1 v1.5 padding. RSASSA-PSS, the other scheme defined by RFC 8017, is not used. Spec: [RFC 8017 (PKCS #1 v2.2)](https://datatracker.ietf.org/doc/html/rfc8017).
+- **PKCS #12 / PFX**: a `.pfx` file bundling a certificate (and its chain) with its private key, usually password-protected. Spec: [RFC 7292](https://datatracker.ietf.org/doc/html/rfc7292).
+- **HSM (Hardware Security Module)**: tamper-resistant hardware that signs without exposing the key. Cloud HSMs (Key Vault Premium, Trusted Signing) and local HSMs (smart cards, USB tokens via CNG) both satisfy the [CA/Browser Forum Code Signing Baseline Requirements](https://cabforum.org/working-groups/code-signing/documents/), which now mandate HSM-backed keys for publicly trusted code-signing certificates.
+- **Digest signing**: a signing approach where the caller pre-computes the content's digest and asks the signer to sign that digest (rather than handing over the content). Sign CLI uses this pattern uniformly: every cryptographic signer calls `RSA.SignHash` on the `RSA` returned by `ISignatureAlgorithmProvider.GetRsaAsync`, never `SignData`. For cloud providers (Key Vault, Trusted Signing) this also keeps file contents off the wire. For the local `certificate-store` provider and PFX files the private key is in process, so the property is purely architectural.
+- **CMS / PKCS #7**: ASN.1 envelope for "signed data" (content, signer info, certs, signed attributes). NuGet, Authenticode (PE, MSI, CAB, CAT, AppX/MSIX, PowerShell scripts, JScript/VBScript), and RFC 3161 timestamp tokens are CMS variants. (VSIX and ClickOnce use XML Digital Signatures instead, not CMS.) Spec: [RFC 5652](https://datatracker.ietf.org/doc/html/rfc5652). .NET API: [`SignedCms`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.pkcs.signedcms).
+- **Authenticode**: Microsoft's signing format for PE, MSI, CAB, CAT, AppX/MSIX, PowerShell scripts, and JScript/VBScript. CMS wraps an `SpcIndirectDataContent` blob (digest plus file-type OID). For PE, the blob lives in the PE certificate table; for MSI, in the `\x05DigitalSignature` OLE compound-document stream. Spec: [Windows Authenticode PE Signature Format](http://download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/Authenticode_PE.docx).
+- **Timestamping (RFC 3161)**: a TSA signs a hash of the signature value, producing a timestamp token that preserves validity past certificate expiry. Specs: [RFC 3161](https://datatracker.ietf.org/doc/html/rfc3161) and [RFC 5816](https://datatracker.ietf.org/doc/html/rfc5816) (`ESSCertIDv2` update).
+- **OPC (Open Packaging Conventions)**: ZIP-based container used by VSIX, Office, XPS. Signature parts live under `/package/services/digital-signature/`. Spec: [ECMA-376 Part 2](https://www.ecma-international.org/publications-and-standards/standards/ecma-376/) (also published as [ISO/IEC 29500-2](https://www.iso.org/standard/77818.html)).
+- **NuGet package signatures**: CMS signature stored as `.signature.p7s` inside the `.nupkg`. Author signatures and repository countersignatures can co-exist. Spec: [NuGet package signatures](https://learn.microsoft.com/nuget/reference/signed-packages-reference).
+- **ClickOnce manifests**: XML files (`.application`, `.vsto`, `.manifest`) signed using [XML Signature](https://www.w3.org/TR/xmldsig-core/). The deployment manifest references the application manifest's digest, so the application manifest must be signed first. The legacy `Mage` and `MageUI` tools were the historical signers.
+
+## Structure at a glance
+
+![SignedCms structure](./images/structures-signedcms.svg)
+
+![X.509 certificate structure](./images/structures-x509.svg)
+
+## Signature formats by file type
+
+Every format below ultimately wraps a CMS `SignedData` (or, for VSIX and ClickOnce, an XML Signature) around a digest of the payload. What differs is where the signature lives and what `eContent` the digest is taken over.
+
+- **Authenticode (PE, MSI, CAB, CAT, AppX/MSIX, PowerShell, JScript, VBScript)**: CMS `SignedData` whose `eContent` is an `SpcIndirectDataContent` ASN.1 blob (file-type OID plus payload digest). For PE, the CMS blob is stored in the certificate table (data directory index `IMAGE_DIRECTORY_ENTRY_SECURITY` in the PE optional header). For MSI (an OLE compound document), it's stored in the `\x05DigitalSignature` stream. For scripts, it's embedded as a base64 block inside a comment-delimited trailer: `# SIG # Begin signature block` for PowerShell, `'** SIG **` for VBScript, `//** SIG **` for JScript. JScript and VBScript signing uses COM and requires an STA thread.
+- **NuGet (`.nupkg`)**: CMS `SignedData` written as the `.signature.p7s` zip entry at the root of the package. `eContent` is a UTF-8 properties document (custom key-value format) carrying a Base64-encoded hash of the unsigned package bytes. Repository countersignatures attach as an unsigned attribute on the author signer.
+- **VSIX and other OPC packages**: XML Signature parts under `/package/services/digital-signature/` inside the zip (`origin.psdor`, `xml-signature/<id>.psdsxs`, plus a DER-encoded `.cer` certificate part). Each referenced part has its own digest; the manifest is what's signed.
+- **ClickOnce (`.application`, `.vsto`, `*.manifest`)**: XML Signature ([XMLDSig](https://www.w3.org/TR/xmldsig-core/)) embedded in the XML manifest. The deployment manifest references the application manifest's digest, so inner manifests must be signed first.
+- **RFC 3161 timestamp tokens**: a nested CMS `SignedData` (`eContent` = `TSTInfo`) attached as an unsigned attribute on the outer signer. Verifiers use the timestamp's `TSTInfo.genTime` to evaluate the signing certificate's validity, so a signature outlives its certificate.
+
+## Verification commands
+
+Useful while debugging signatures Sign CLI produces.
+
+- PE / MSI: `signtool verify /pa /v <file>` or PowerShell `Get-AuthenticodeSignature <file> | Format-List *`.
+- NuGet: `nuget verify -All <pkg>` or `dotnet nuget verify <pkg>`.
+- VSIX / OPC: [`vsixsigntool`](https://www.nuget.org/packages/Microsoft.VSSDK.VsixSignTool) `verify /v <file>` or unzip and inspect `/package/services/digital-signature/`. Note: `vsixsigntool` is separate from the OPC signing code vendored under `src/Sign.Core/Tools/VsixSignTool/`.
+- Any CMS blob: `certutil -asn -v <file>`.
+- Any certificate: `certutil -dump <cert>`.


### PR DESCRIPTION
Add cryptographic primer for Sign CLI maintainers covering vocabulary, ASN.1 structure diagrams, signature formats by file type, and verification commands.

CC @kartheekp-ms, @aortiz-msft