### PR TITLE
Pin actions/stale to a commit SHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 10 days with no activity after asking for more info. Comment or this will be closed in 4 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity. This can be reopened if additional information is provided.'


### PR DESCRIPTION
The stale-issue workflow referenced actions/stale@v9, a mutable tag. If that tag were moved to a malicious commit (tag hijack or a compromised upstream), the altered action would run in this repository's workflow with the granted GITHUB_TOKEN permissions. Pinning to the full commit SHA that v9 currently resolves to makes the referenced action immutable while a trailing comment preserves the human-readable version.

    actions/stale@v9 -> actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0


Copilot-Session: 75a78ee2-2777-4175-bd61-9a549bc42623