### PR TITLE
Migrate tests from Moq to NSubstitute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
-    <PackageVersion Include="NSubstitute" Version="6.1.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
-    <!-- We're staying on 4.18.4 until we migrate to another mocking framework.
-         See https://github.com/dotnet/runtime/issues/90222 and https://github.com/devlooped/moq/issues/1374
-         for context.   -->
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="NSubstitute" Version="6.1.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
@@ -21,7 +22,6 @@
       <package pattern="coverlet.collector" />
       <package pattern="MicroBuild.Core" />
       <package pattern="Microsoft.*" />
-      <package pattern="Moq" />
       <package pattern="Newtonsoft.Json" />
       <package pattern="NuGet.*" />
       <!-- Used by Arcade -->
@@ -29,6 +29,10 @@
       <package pattern="System.*" />
       <package pattern="vswhere" />
       <package pattern="xunit.*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="NSubstitute" />
+      <package pattern="NSubstitute.Analyzers.CSharp" />
     </packageSource>
     <packageSource key="dotnet-tools">
       <package pattern="sn" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
@@ -23,16 +22,14 @@
       <package pattern="MicroBuild.Core" />
       <package pattern="Microsoft.*" />
       <package pattern="Newtonsoft.Json" />
+      <package pattern="NSubstitute" />
+      <package pattern="NSubstitute.Analyzers.CSharp" />
       <package pattern="NuGet.*" />
       <!-- Used by Arcade -->
       <package pattern="sourcelink" />
       <package pattern="System.*" />
       <package pattern="vswhere" />
       <package pattern="xunit.*" />
-    </packageSource>
-    <packageSource key="nuget.org">
-      <package pattern="NSubstitute" />
-      <package pattern="NSubstitute.Analyzers.CSharp" />
     </packageSource>
     <packageSource key="dotnet-tools">
       <package pattern="sn" />

--- a/test/Sign.Cli.Test/ArtifactSigningCommandTests.cs
+++ b/test/Sign.Cli.Test/ArtifactSigningCommandTests.cs
@@ -1,22 +1,22 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
-using Moq;
+using NSubstitute;
 using Sign.Core;
 
 namespace Sign.Cli.Test
 {
     public class ArtifactSigningCommandTests
     {
-        private readonly ArtifactSigningCommand _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
+        private readonly ArtifactSigningCommand _command = new(new CodeCommand(), Substitute.For<IServiceProviderFactory>());
 
         [Fact]
         public void Constructor_WhenCodeCommandIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new ArtifactSigningCommand(codeCommand: null!, Mock.Of<IServiceProviderFactory>()));
+                () => new ArtifactSigningCommand(codeCommand: null!, Substitute.For<IServiceProviderFactory>()));
 
             Assert.Equal("codeCommand", exception.ParamName);
         }
@@ -74,7 +74,7 @@ namespace Sign.Cli.Test
             public ParserTests()
             {
                 CodeCommand codeCommand = new();
-                _command = new(codeCommand, Mock.Of<IServiceProviderFactory>());
+                _command = new(codeCommand, Substitute.For<IServiceProviderFactory>());
                 _rootCommand = new RootCommand();
                 _rootCommand.Subcommands.Add(codeCommand);
                 codeCommand.Subcommands.Add(_command);

--- a/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
+++ b/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
 using Azure.Core;
 using Azure.Identity;
-using Moq;
+using NSubstitute;
 using Sign.Core;
 
 namespace Sign.Cli.Test
@@ -19,7 +19,7 @@ namespace Sign.Cli.Test
         public AzureCredentialOptionsTests()
         {
             CodeCommand codeCommand = new();
-            _command = new(codeCommand, Mock.Of<IServiceProviderFactory>());
+            _command = new(codeCommand, Substitute.For<IServiceProviderFactory>());
             _rootCommand = new RootCommand();
             _rootCommand.Subcommands.Add(codeCommand);
             codeCommand.Subcommands.Add(_command);

--- a/test/Sign.Cli.Test/AzureKeyVaultCommandTests.cs
+++ b/test/Sign.Cli.Test/AzureKeyVaultCommandTests.cs
@@ -1,22 +1,22 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
-using Moq;
+using NSubstitute;
 using Sign.Core;
 
 namespace Sign.Cli.Test
 {
     public class AzureKeyVaultCommandTests
     {
-        private readonly AzureKeyVaultCommand _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
+        private readonly AzureKeyVaultCommand _command = new(new CodeCommand(), Substitute.For<IServiceProviderFactory>());
 
         [Fact]
         public void Constructor_WhenCodeCommandIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new AzureKeyVaultCommand(codeCommand: null!, Mock.Of<IServiceProviderFactory>()));
+                () => new AzureKeyVaultCommand(codeCommand: null!, Substitute.For<IServiceProviderFactory>()));
 
             Assert.Equal("codeCommand", exception.ParamName);
         }
@@ -62,7 +62,7 @@ namespace Sign.Cli.Test
             public ParserTests()
             {
                 CodeCommand codeCommand = new();
-                _command = new(codeCommand, Mock.Of<IServiceProviderFactory>());
+                _command = new(codeCommand, Substitute.For<IServiceProviderFactory>());
                 _rootCommand = new RootCommand();
                 _rootCommand.Subcommands.Add(codeCommand);
                 codeCommand.Subcommands.Add(_command);

--- a/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
+++ b/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
@@ -1,16 +1,16 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
-using Moq;
+using NSubstitute;
 using Sign.Core;
 
 namespace Sign.Cli.Test
 {
     public class CertificateStoreCommandTests
     {
-        private readonly CertificateStoreCommand _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
+        private readonly CertificateStoreCommand _command = new(new CodeCommand(), Substitute.For<IServiceProviderFactory>());
 
         private const string Sha1Fingerprint = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
         private const string Sha256Fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -21,7 +21,7 @@ namespace Sign.Cli.Test
         public void Constructor_WhenCodeCommandIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreCommand(codeCommand: null!, Mock.Of<IServiceProviderFactory>()));
+                () => new CertificateStoreCommand(codeCommand: null!, Substitute.For<IServiceProviderFactory>()));
 
             Assert.Equal("codeCommand", exception.ParamName);
         }
@@ -79,7 +79,7 @@ namespace Sign.Cli.Test
             public ParserTests()
             {
                 CodeCommand codeCommand = new();
-                _command = new CertificateStoreCommand(codeCommand, Mock.Of<IServiceProviderFactory>());
+                _command = new CertificateStoreCommand(codeCommand, Substitute.For<IServiceProviderFactory>());
                 _rootCommand = new RootCommand();
                 _rootCommand.Subcommands.Add(codeCommand);
                 codeCommand.Subcommands.Add(_command);

--- a/test/Sign.Cli.Test/Sign.Cli.Test.csproj
+++ b/test/Sign.Cli.Test/Sign.Cli.Test.csproj
@@ -11,7 +11,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" PrivateAssets="all" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <IncludeAssets>analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sign.Cli.Test/SignCommandTests.Globbing.cs
+++ b/test/Sign.Cli.Test/SignCommandTests.Globbing.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.Core;
 
 namespace Sign.Cli.Test
@@ -33,7 +33,7 @@ namespace Sign.Cli.Test
 
                 _signCommand = Program.CreateCommand(serviceProviderFactory);
 
-                _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+                _directoryService = new DirectoryService(Substitute.For<ILogger<IDirectoryService>>());
                 _temporaryDirectory = new TemporaryDirectory(_directoryService);
 
                 CreateFileSystemInfos(

--- a/test/Sign.Cli.Test/TrustedSigningCommandTests.cs
+++ b/test/Sign.Cli.Test/TrustedSigningCommandTests.cs
@@ -1,22 +1,22 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
-using Moq;
+using NSubstitute;
 using Sign.Core;
 
 namespace Sign.Cli.Test
 {
     public class TrustedSigningCommandTests
     {
-        private readonly TrustedSigningCommand _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
+        private readonly TrustedSigningCommand _command = new(new CodeCommand(), Substitute.For<IServiceProviderFactory>());
 
         [Fact]
         public void Constructor_WhenCodeCommandIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new TrustedSigningCommand(codeCommand: null!, Mock.Of<IServiceProviderFactory>()));
+                () => new TrustedSigningCommand(codeCommand: null!, Substitute.For<IServiceProviderFactory>()));
 
             Assert.Equal("codeCommand", exception.ParamName);
         }
@@ -80,7 +80,7 @@ namespace Sign.Cli.Test
             public ParserTests()
             {
                 CodeCommand codeCommand = new();
-                _command = new(codeCommand, Mock.Of<IServiceProviderFactory>());
+                _command = new(codeCommand, Substitute.For<IServiceProviderFactory>());
                 _rootCommand = new RootCommand();
                 _rootCommand.Subcommands.Add(codeCommand);
                 codeCommand.Subcommands.Add(_command);

--- a/test/Sign.Core.Test/Certificates/CertificateVerifierTests.cs
+++ b/test/Sign.Core.Test/Certificates/CertificateVerifierTests.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
@@ -23,7 +23,7 @@ namespace Sign.Core.Test
         [Fact]
         public void Verify_WhenCertificateIsNull_Throws()
         {
-            CertificateVerifier verifier = new(Mock.Of<ILogger<ICertificateVerifier>>());
+            CertificateVerifier verifier = new(Substitute.For<ILogger<ICertificateVerifier>>());
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => verifier.Verify(certificate: null!));

--- a/test/Sign.Core.Test/Containers/AppxBundleContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/AppxBundleContainerTests.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -15,10 +15,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxBundleContainer(
                     appxBundle: null!,
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("appxBundle", exception.ParamName);
         }
@@ -30,9 +30,9 @@ namespace Sign.Core.Test
                 () => new AppxBundleContainer(
                     new FileInfo("a"),
                     directoryService: null!,
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("directoryService", exception.ParamName);
         }
@@ -43,10 +43,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxBundleContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
+                    Substitute.For<IDirectoryService>(),
                     fileMatcher: null!,
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("fileMatcher", exception.ParamName);
         }
@@ -57,10 +57,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxBundleContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
                     makeAppxCli: null!,
-                    Mock.Of<ILogger>()));
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("makeAppxCli", exception.ParamName);
         }
@@ -71,9 +71,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxBundleContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);

--- a/test/Sign.Core.Test/Containers/AppxContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/AppxContainerTests.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -15,11 +15,11 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxContainer(
                     appx: null!,
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainer>>()));
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainer>>()));
 
             Assert.Equal("appx", exception.ParamName);
         }
@@ -31,10 +31,10 @@ namespace Sign.Core.Test
                 () => new AppxContainer(
                     appx: new FileInfo("a"),
                     certificateProvider: null!,
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainer>>()));
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainer>>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
         }
@@ -45,11 +45,11 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxContainer(
                     appx: new FileInfo("a"),
-                    Mock.Of<ICertificateProvider>(),
+                    Substitute.For<ICertificateProvider>(),
                     directoryService: null!,
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainer>>()));
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainer>>()));
 
             Assert.Equal("directoryService", exception.ParamName);
         }
@@ -60,11 +60,11 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxContainer(
                     appx: new FileInfo("a"),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
                     fileMatcher: null!,
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainer>>()));
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainer>>()));
 
             Assert.Equal("fileMatcher", exception.ParamName);
         }
@@ -75,11 +75,11 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxContainer(
                     appx: new FileInfo("a"),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
                     makeAppxCli: null!,
-                    Mock.Of<ILogger<IContainer>>()));
+                    Substitute.For<ILogger<IContainer>>()));
 
             Assert.Equal("makeAppxCli", exception.ParamName);
         }
@@ -90,10 +90,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppxContainer(
                     appx: new FileInfo("a"),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);

--- a/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
+++ b/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -14,11 +14,11 @@ namespace Sign.Core.Test
         public ContainerProviderTests()
         {
             _provider = new ContainerProvider(
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<IDirectoryService>(),
-                Mock.Of<IFileMatcher>(),
-                Mock.Of<IMakeAppxCli>(),
-                Mock.Of<ILogger<IContainerProvider>>());
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<IDirectoryService>(),
+                Substitute.For<IFileMatcher>(),
+                Substitute.For<IMakeAppxCli>(),
+                Substitute.For<ILogger<IContainerProvider>>());
         }
 
         [Fact]
@@ -27,10 +27,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ContainerProvider(
                     certificateProvider: null!,
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainerProvider>>()));
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainerProvider>>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
         }
@@ -40,11 +40,11 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ContainerProvider(
-                    Mock.Of<ICertificateProvider>(),
+                    Substitute.For<ICertificateProvider>(),
                     directoryService: null!,
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainerProvider>>()));
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainerProvider>>()));
 
             Assert.Equal("directoryService", exception.ParamName);
         }
@@ -54,11 +54,11 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ContainerProvider(
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
                     fileMatcher: null!,
-                    Mock.Of<IMakeAppxCli>(),
-                    Mock.Of<ILogger<IContainerProvider>>()));
+                    Substitute.For<IMakeAppxCli>(),
+                    Substitute.For<ILogger<IContainerProvider>>()));
 
             Assert.Equal("fileMatcher", exception.ParamName);
         }
@@ -68,11 +68,11 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ContainerProvider(
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
                     makeAppxCli: null!,
-                    Mock.Of<ILogger<IContainerProvider>>()));
+                    Substitute.For<ILogger<IContainerProvider>>()));
 
             Assert.Equal("makeAppxCli", exception.ParamName);
         }
@@ -82,10 +82,10 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ContainerProvider(
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<IMakeAppxCli>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<IMakeAppxCli>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);

--- a/test/Sign.Core.Test/Containers/NuGetContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/NuGetContainerTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.IO.Compression;
 using System.Text;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using NuGet.Packaging.Signing;
 
 namespace Sign.Core.Test
@@ -18,9 +18,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetContainer(
                     zipFile: null!,
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("zipFile", exception.ParamName);
         }
@@ -32,8 +32,8 @@ namespace Sign.Core.Test
                 () => new NuGetContainer(
                     new FileInfo("a"),
                     directoryService: null!,
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("directoryService", exception.ParamName);
         }
@@ -44,9 +44,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
+                    Substitute.For<IDirectoryService>(),
                     fileMatcher: null!,
-                    Mock.Of<ILogger>()));
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("fileMatcher", exception.ParamName);
         }
@@ -57,8 +57,8 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
@@ -74,7 +74,7 @@ namespace Sign.Core.Test
             {
                 DirectoryInfo? directory;
 
-                using (NuGetContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+                using (NuGetContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
                 {
                     await container.OpenAsync();
 
@@ -96,7 +96,7 @@ namespace Sign.Core.Test
             FileInfo zipFile = CreateZipFile(expectedFileNames);
 
             using (DirectoryServiceStub directoryService = new())
-            using (NuGetContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+            using (NuGetContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
             {
                 await container.OpenAsync();
 
@@ -116,7 +116,7 @@ namespace Sign.Core.Test
             FileInfo zipFile = CreateZipFile(fileNames);
 
             using (DirectoryServiceStub directoryService = new())
-            using (NuGetContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+            using (NuGetContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
             {
                 await container.OpenAsync();
 
@@ -141,7 +141,7 @@ namespace Sign.Core.Test
             FileInfo zipFile = CreateZipFile(fileNames);
 
             using (DirectoryServiceStub directoryService = new())
-            using (NuGetContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+            using (NuGetContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
             {
                 await container.OpenAsync();
                 await container.SaveAsync();

--- a/test/Sign.Core.Test/Containers/ZipContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/ZipContainerTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.IO.Compression;
 using System.Text;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -17,9 +17,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ZipContainer(
                     zipFile: null!,
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("zipFile", exception.ParamName);
         }
@@ -31,8 +31,8 @@ namespace Sign.Core.Test
                 () => new ZipContainer(
                     new FileInfo("a"),
                     directoryService: null!,
-                    Mock.Of<IFileMatcher>(),
-                    Mock.Of<ILogger>()));
+                    Substitute.For<IFileMatcher>(),
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("directoryService", exception.ParamName);
         }
@@ -43,9 +43,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ZipContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
+                    Substitute.For<IDirectoryService>(),
                     fileMatcher: null!,
-                    Mock.Of<ILogger>()));
+                    Substitute.For<ILogger>()));
 
             Assert.Equal("fileMatcher", exception.ParamName);
         }
@@ -56,8 +56,8 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ZipContainer(
                     new FileInfo("a"),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IFileMatcher>(),
+                    Substitute.For<IDirectoryService>(),
+                    Substitute.For<IFileMatcher>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
@@ -73,7 +73,7 @@ namespace Sign.Core.Test
             {
                 DirectoryInfo? directory;
 
-                using (ZipContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+                using (ZipContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
                 {
                     await container.OpenAsync();
 
@@ -95,7 +95,7 @@ namespace Sign.Core.Test
             FileInfo zipFile = CreateZipFile(expectedFileNames);
 
             using (DirectoryServiceStub directoryService = new())
-            using (ZipContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+            using (ZipContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
             {
                 await container.OpenAsync();
 
@@ -115,7 +115,7 @@ namespace Sign.Core.Test
             FileInfo zipFile = CreateZipFile(fileNames);
 
             using (DirectoryServiceStub directoryService = new())
-            using (ZipContainer container = new(zipFile, directoryService, Mock.Of<IFileMatcher>(), Mock.Of<ILogger>()))
+            using (ZipContainer container = new(zipFile, directoryService, Substitute.For<IFileMatcher>(), Substitute.For<ILogger>()))
             {
                 await container.OpenAsync();
 

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography;
 using Microsoft.Extensions.FileSystemGlobbing;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -18,10 +18,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AggregatingSigner(
                     signers: null!,
-                    Mock.Of<IDefaultDataFormatSigner>(),
-                    Mock.Of<IContainerProvider>(),
-                    Mock.Of<IFileMetadataService>(),
-                    Mock.Of<IMatcherFactory>()));
+                    Substitute.For<IDefaultDataFormatSigner>(),
+                    Substitute.For<IContainerProvider>(),
+                    Substitute.For<IFileMetadataService>(),
+                    Substitute.For<IMatcherFactory>()));
 
             Assert.Equal("signers", exception.ParamName);
         }
@@ -33,9 +33,9 @@ namespace Sign.Core.Test
                 () => new AggregatingSigner(
                     Enumerable.Empty<IDataFormatSigner>(),
                     defaultSigner: null!,
-                    Mock.Of<IContainerProvider>(),
-                    Mock.Of<IFileMetadataService>(),
-                    Mock.Of<IMatcherFactory>()));
+                    Substitute.For<IContainerProvider>(),
+                    Substitute.For<IFileMetadataService>(),
+                    Substitute.For<IMatcherFactory>()));
 
             Assert.Equal("defaultSigner", exception.ParamName);
         }
@@ -46,10 +46,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AggregatingSigner(
                     Enumerable.Empty<IDataFormatSigner>(),
-                    Mock.Of<IDefaultDataFormatSigner>(),
+                    Substitute.For<IDefaultDataFormatSigner>(),
                     containerProvider: null!,
-                    Mock.Of<IFileMetadataService>(),
-                    Mock.Of<IMatcherFactory>()));
+                    Substitute.For<IFileMetadataService>(),
+                    Substitute.For<IMatcherFactory>()));
 
             Assert.Equal("containerProvider", exception.ParamName);
         }
@@ -60,10 +60,10 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AggregatingSigner(
                     Enumerable.Empty<IDataFormatSigner>(),
-                    Mock.Of<IDefaultDataFormatSigner>(),
-                    Mock.Of<IContainerProvider>(),
+                    Substitute.For<IDefaultDataFormatSigner>(),
+                    Substitute.For<IContainerProvider>(),
                     fileMetadataService: null!,
-                    Mock.Of<IMatcherFactory>()));
+                    Substitute.For<IMatcherFactory>()));
 
             Assert.Equal("fileMetadataService", exception.ParamName);
         }
@@ -74,9 +74,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AggregatingSigner(
                     Enumerable.Empty<IDataFormatSigner>(),
-                    Mock.Of<IDefaultDataFormatSigner>(),
-                    Mock.Of<IContainerProvider>(),
-                    Mock.Of<IFileMetadataService>(),
+                    Substitute.For<IDefaultDataFormatSigner>(),
+                    Substitute.For<IContainerProvider>(),
+                    Substitute.For<IFileMetadataService>(),
                     matcherFactory: null!));
 
             Assert.Equal("matcherFactory", exception.ParamName);
@@ -97,34 +97,32 @@ namespace Sign.Core.Test
         public void CanSign_WhenSignerReturnsTrue_ReturnsTrue()
         {
             const string extension = ".xyz";
+            FileInfo file = new($"file{extension}");
+            IDataFormatSigner signer = Substitute.For<IDataFormatSigner>();
 
-            Mock<IDataFormatSigner> signer = new(MockBehavior.Strict);
+            signer.CanSign(Arg.Any<FileInfo>()).Returns(true);
+            signer.ClearReceivedCalls();
+            AggregatingSigner aggregatingSigner = CreateSigner(signer);
 
-            signer.Setup(x => x.CanSign(It.IsAny<FileInfo>()))
-                .Returns(true);
-
-            AggregatingSigner aggregatingSigner = CreateSigner(signer.Object);
-
-            Assert.True(aggregatingSigner.CanSign(new FileInfo($"file{extension}")));
-
-            signer.VerifyAll();
+            Assert.True(aggregatingSigner.CanSign(file));
+            signer.Received(1).CanSign(Arg.Is<FileInfo>(f => ReferenceEquals(f, file)));
+            Assert.Single(signer.ReceivedCalls());
         }
 
         [Fact]
         public void CanSign_WhenSignerReturnsFalse_ReturnsFalse()
         {
             const string extension = ".xyz";
+            FileInfo file = new($"file{extension}");
+            IDataFormatSigner signer = Substitute.For<IDataFormatSigner>();
 
-            Mock<IDataFormatSigner> signer = new(MockBehavior.Strict);
+            signer.CanSign(Arg.Any<FileInfo>()).Returns(false);
+            signer.ClearReceivedCalls();
+            AggregatingSigner aggregatingSigner = CreateSigner(signer);
 
-            signer.Setup(x => x.CanSign(It.IsAny<FileInfo>()))
-                .Returns(false);
-
-            AggregatingSigner aggregatingSigner = CreateSigner(signer.Object);
-
-            Assert.False(aggregatingSigner.CanSign(new FileInfo($"file{extension}")));
-
-            signer.VerifyAll();
+            Assert.False(aggregatingSigner.CanSign(file));
+            signer.Received(1).CanSign(Arg.Is<FileInfo>(f => ReferenceEquals(f, file)));
+            Assert.Single(signer.ReceivedCalls());
         }
 
         [Theory]
@@ -182,17 +180,15 @@ namespace Sign.Core.Test
                 signers = [signer];
             }
 
-            Mock<IMatcherFactory> matcherFactory = new();
-
-            matcherFactory.Setup(x => x.Create())
-                .Returns(new Matcher(StringComparison.OrdinalIgnoreCase));
+            IMatcherFactory matcherFactory = Substitute.For<IMatcherFactory>();
+            matcherFactory.Create().Returns(new Matcher(StringComparison.OrdinalIgnoreCase));
 
             return new AggregatingSigner(
                 signers,
-                Mock.Of<IDefaultDataFormatSigner>(),
-                Mock.Of<IContainerProvider>(),
-                Mock.Of<IFileMetadataService>(),
-                matcherFactory.Object);
+                Substitute.For<IDefaultDataFormatSigner>(),
+                Substitute.For<IContainerProvider>(),
+                Substitute.For<IFileMetadataService>(),
+                matcherFactory);
         }
     }
 }

--- a/test/Sign.Core.Test/DataFormatSigners/AppInstallerServiceSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AppInstallerServiceSignerTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Text;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -16,8 +16,8 @@ namespace Sign.Core.Test
         public AppInstallerServiceSignerTests()
         {
             _signer = new AppInstallerServiceSigner(
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<ILogger<IDataFormatSigner>>());
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppInstallerServiceSigner(
                     certificateProvider: null!,
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
         }
@@ -36,7 +36,7 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new AppInstallerServiceSigner(
-                    Mock.Of<ICertificateProvider>(),
+                    Substitute.For<ICertificateProvider>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);

--- a/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
@@ -184,8 +184,6 @@ namespace Sign.Core.Test
 
                     await signatureAlgorithmProvider.Received(1).GetRsaAsync(Arg.Any<CancellationToken>());
                     await certificateProvider.Received(1).GetCertificateAsync(Arg.Any<CancellationToken>());
-                    Assert.Single(signatureAlgorithmProvider.ReceivedCalls());
-                    Assert.Single(certificateProvider.ReceivedCalls());
                 }
             }
         }

--- a/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
@@ -8,7 +8,7 @@ using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using AzureSign.Core;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
@@ -25,12 +25,12 @@ namespace Sign.Core.Test
             ArgumentNullException.ThrowIfNull(certificateFixture, nameof(certificateFixture));
 
             _certificateFixture = certificateFixture;
-            _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
+            _directoryService = new(Substitute.For<ILogger<IDirectoryService>>());
             _signer = new AzureSignToolSigner(
-                Mock.Of<IToolConfigurationProvider>(),
-                Mock.Of<ISignatureAlgorithmProvider>(),
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<IToolConfigurationProvider>(),
+                Substitute.For<ISignatureAlgorithmProvider>(),
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<ILogger<IDataFormatSigner>>());
         }
 
         public void Dispose()
@@ -150,21 +150,19 @@ namespace Sign.Core.Test
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
                 {
                     ToolConfigurationProvider toolConfigurationProvider = new(new AppRootDirectoryLocator());
-                    Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-                    Mock<ICertificateProvider> certificateProvider = new();
+                    ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+                    ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+                    certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(new X509Certificate2(certificate));
+                    signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(privateKey);
+                    certificateProvider.ClearReceivedCalls();
+                    signatureAlgorithmProvider.ClearReceivedCalls();
 
-                    certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(new X509Certificate2(certificate));
-
-                    signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(privateKey);
-
-                    ILogger<IDataFormatSigner> logger = Mock.Of<ILogger<IDataFormatSigner>>();
+                    ILogger<IDataFormatSigner> logger = Substitute.For<ILogger<IDataFormatSigner>>();
 
                     AzureSignToolSigner signer = new(
                         toolConfigurationProvider,
-                        signatureAlgorithmProvider.Object,
-                        certificateProvider.Object,
+                        signatureAlgorithmProvider,
+                        certificateProvider,
                         logger);
 
                     await signer.SignAsync(new[] { file }, options);
@@ -184,8 +182,10 @@ namespace Sign.Core.Test
 
                     signedCms.CheckSignature(verifySignatureOnly: true);
 
-                    signatureAlgorithmProvider.VerifyAll();
-                    certificateProvider.VerifyAll();
+                    await signatureAlgorithmProvider.Received(1).GetRsaAsync(Arg.Any<CancellationToken>());
+                    await certificateProvider.Received(1).GetCertificateAsync(Arg.Any<CancellationToken>());
+                    Assert.Single(signatureAlgorithmProvider.ReceivedCalls());
+                    Assert.Single(certificateProvider.ReceivedCalls());
                 }
             }
         }
@@ -200,14 +200,10 @@ namespace Sign.Core.Test
             CertificateRequest req = new("CN=Test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             using X509Certificate2 certificate = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddDays(1));
 
-            Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-            Mock<ICertificateProvider> certificateProvider = new();
-
-            certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new X509Certificate2(certificate.Export(X509ContentType.Pfx)));
-
-            signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(RSA.Create(rsa.ExportParameters(includePrivateParameters: true)));
+            ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+            ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+            certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(new X509Certificate2(certificate.Export(X509ContentType.Pfx)));
+            signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(RSA.Create(rsa.ExportParameters(includePrivateParameters: true)));
 
             SignOptions options = new(
                 applicationName: null,
@@ -222,10 +218,10 @@ namespace Sign.Core.Test
                 recurseContainers: true);
 
             TestableAzureSignToolSigner signer = new(
-                Mock.Of<IToolConfigurationProvider>(),
-                signatureAlgorithmProvider.Object,
-                certificateProvider.Object,
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<IToolConfigurationProvider>(),
+                signatureAlgorithmProvider,
+                certificateProvider,
+                Substitute.For<ILogger<IDataFormatSigner>>());
 
             FileInfo file = new($"test{extension}");
 
@@ -243,14 +239,10 @@ namespace Sign.Core.Test
             CertificateRequest req = new("CN=Test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             using X509Certificate2 certificate = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddDays(1));
 
-            Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-            Mock<ICertificateProvider> certificateProvider = new();
-
-            certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new X509Certificate2(certificate.Export(X509ContentType.Pfx)));
-
-            signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(RSA.Create(rsa.ExportParameters(includePrivateParameters: true)));
+            ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+            ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+            certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(new X509Certificate2(certificate.Export(X509ContentType.Pfx)));
+            signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(RSA.Create(rsa.ExportParameters(includePrivateParameters: true)));
 
             SignOptions options = new(
                 applicationName: null,
@@ -265,10 +257,10 @@ namespace Sign.Core.Test
                 recurseContainers: true);
 
             TestableAzureSignToolSigner signer = new(
-                Mock.Of<IToolConfigurationProvider>(),
-                signatureAlgorithmProvider.Object,
-                certificateProvider.Object,
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<IToolConfigurationProvider>(),
+                signatureAlgorithmProvider,
+                certificateProvider,
+                Substitute.For<ILogger<IDataFormatSigner>>());
 
             FileInfo[] files = new[]
             {
@@ -312,14 +304,10 @@ namespace Sign.Core.Test
             CertificateRequest req = new("CN=Test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             using X509Certificate2 certificate = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddDays(1));
 
-            Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-            Mock<ICertificateProvider> certificateProvider = new();
-
-            certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new X509Certificate2(certificate.Export(X509ContentType.Pfx)));
-
-            signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(RSA.Create(rsa.ExportParameters(includePrivateParameters: true)));
+            ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+            ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+            certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(new X509Certificate2(certificate.Export(X509ContentType.Pfx)));
+            signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(RSA.Create(rsa.ExportParameters(includePrivateParameters: true)));
 
             SignOptions options = new(
                 applicationName: null,
@@ -334,10 +322,10 @@ namespace Sign.Core.Test
                 recurseContainers: true);
 
             TestableAzureSignToolSigner signer = new(
-                Mock.Of<IToolConfigurationProvider>(),
-                signatureAlgorithmProvider.Object,
-                certificateProvider.Object,
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<IToolConfigurationProvider>(),
+                signatureAlgorithmProvider,
+                certificateProvider,
+                Substitute.For<ILogger<IDataFormatSigner>>());
 
             FileInfo file = new("test.dll");
 

--- a/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
@@ -396,12 +396,12 @@ namespace Sign.Core.Test
                         args,
                         StringComparison.Ordinal)));
                     manifestSigner.Received(1).Sign(
-                        Arg.Is<FileInfo>(fi => fi.Name == manifestFile.Name),
+                        Arg.Is<FileInfo>(fi => fi != null && fi.Name == manifestFile.Name),
                         Arg.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
                         Arg.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
                         Arg.Is<SignOptions>(o => ReferenceEquals(options, o)));
                     manifestSigner.Received(1).Sign(
-                        Arg.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
+                        Arg.Is<FileInfo>(fi => fi != null && fi.Name == applicationFile.Name),
                         Arg.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
                         Arg.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
                         Arg.Is<SignOptions>(o => ReferenceEquals(options, o)));
@@ -495,7 +495,7 @@ namespace Sign.Core.Test
                     Assert.Empty(aggregatingSignerSpy.FilesSubmittedForSigning);
                     await mageCli.Received(1).RunAsync(Arg.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal)));
                     manifestSigner.Received(1).Sign(
-                        Arg.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
+                        Arg.Is<FileInfo>(fi => fi != null && fi.Name == applicationFile.Name),
                         Arg.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
                         Arg.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
                         Arg.Is<SignOptions>(o => ReferenceEquals(options, o)));

--- a/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
@@ -17,15 +17,15 @@ namespace Sign.Core.Test
 
         public ClickOnceSignerTests()
         {
-            _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
+            _directoryService = new(Substitute.For<ILogger<IDirectoryService>>());
             _signer = new ClickOnceSigner(
-                Mock.Of<ISignatureAlgorithmProvider>(),
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<IServiceProvider>(),
-                Mock.Of<IMageCli>(),
-                Mock.Of<IManifestSigner>(),
-                Mock.Of<ILogger<IDataFormatSigner>>(),
-                Mock.Of<IFileMatcher>());
+                Substitute.For<ISignatureAlgorithmProvider>(),
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<IServiceProvider>(),
+                Substitute.For<IMageCli>(),
+                Substitute.For<IManifestSigner>(),
+                Substitute.For<ILogger<IDataFormatSigner>>(),
+                Substitute.For<IFileMatcher>());
         }
 
         public void Dispose()
@@ -39,12 +39,12 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
                     signatureAlgorithmProvider: null!,
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IServiceProvider>(),
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>(),
-                    Mock.Of<IFileMatcher>()));
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IServiceProvider>(),
+                    Substitute.For<IMageCli>(),
+                    Substitute.For<IManifestSigner>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>(),
+                    Substitute.For<IFileMatcher>()));
 
             Assert.Equal("signatureAlgorithmProvider", exception.ParamName);
         }
@@ -54,13 +54,13 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
                     certificateProvider: null!,
-                    Mock.Of<IServiceProvider>(),
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>(),
-                    Mock.Of<IFileMatcher>()));
+                    Substitute.For<IServiceProvider>(),
+                    Substitute.For<IMageCli>(),
+                    Substitute.For<IManifestSigner>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>(),
+                    Substitute.For<IFileMatcher>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
         }
@@ -70,13 +70,13 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
                     serviceProvider: null!,
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>(),
-                    Mock.Of<IFileMatcher>()));
+                    Substitute.For<IMageCli>(),
+                    Substitute.For<IManifestSigner>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>(),
+                    Substitute.For<IFileMatcher>()));
 
             Assert.Equal("serviceProvider", exception.ParamName);
         }
@@ -86,13 +86,13 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IServiceProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IServiceProvider>(),
                     mageCli: null!,
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>(),
-                    Mock.Of<IFileMatcher>()));
+                    Substitute.For<IManifestSigner>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>(),
+                    Substitute.For<IFileMatcher>()));
 
             Assert.Equal("mageCli", exception.ParamName);
         }
@@ -102,13 +102,13 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IServiceProvider>(),
-                    Mock.Of<IMageCli>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IServiceProvider>(),
+                    Substitute.For<IMageCli>(),
                     manifestSigner: null!,
-                    Mock.Of<ILogger<IDataFormatSigner>>(),
-                    Mock.Of<IFileMatcher>()));
+                    Substitute.For<ILogger<IDataFormatSigner>>(),
+                    Substitute.For<IFileMatcher>()));
 
             Assert.Equal("manifestSigner", exception.ParamName);
         }
@@ -118,13 +118,13 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IServiceProvider>(),
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IServiceProvider>(),
+                    Substitute.For<IMageCli>(),
+                    Substitute.For<IManifestSigner>(),
                     logger: null!,
-                    Mock.Of<IFileMatcher>()));
+                    Substitute.For<IFileMatcher>()));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -134,12 +134,12 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new ClickOnceSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IServiceProvider>(),
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IServiceProvider>(),
+                    Substitute.For<IMageCli>(),
+                    Substitute.For<IManifestSigner>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>(),
                     fileMatcher: null!));
 
             Assert.Equal("fileMatcher", exception.ParamName);
@@ -231,46 +231,31 @@ namespace Sign.Core.Test
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
                 {
-                    Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-                    Mock<ICertificateProvider> certificateProvider = new();
+                    ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+                    ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+                    certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(certificate);
+                    signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(privateKey);
 
-                    certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(certificate);
-
-                    signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(privateKey);
-
-                    Mock<IServiceProvider> serviceProvider = new();
+                    IServiceProvider serviceProvider = Substitute.For<IServiceProvider>();
                     AggregatingSignerSpy aggregatingSignerSpy = new();
+                    serviceProvider.GetService(Arg.Any<Type>()).Returns(aggregatingSignerSpy);
 
-                    serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
-                        .Returns(aggregatingSignerSpy);
+                    IMageCli mageCli = Substitute.For<IMageCli>();
+                    mageCli.RunAsync(Arg.Any<string>()).Returns(1);
+                    mageCli.ClearReceivedCalls();
 
-                    Mock<IMageCli> mageCli = new();
-
-                    mageCli.Setup(x => x.RunAsync(
-                            It.IsAny<string>()))
-                        .ReturnsAsync(1);
-
-                    Mock<IManifestSigner> manifestSigner = new();
-                    Mock<IFileMatcher> fileMatcher = new();
-                    Mock<ILogger<IDataFormatSigner>> logger = new();
-
-                    manifestSigner.Setup(
-                        x => x.Sign(
-                            It.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
-                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
-                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
-                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
+                    IManifestSigner manifestSigner = Substitute.For<IManifestSigner>();
+                    IFileMatcher fileMatcher = Substitute.For<IFileMatcher>();
+                    ILogger<IDataFormatSigner> logger = Substitute.For<ILogger<IDataFormatSigner>>();
 
                     ClickOnceSigner signer = new(
-                        signatureAlgorithmProvider.Object,
-                        certificateProvider.Object,
-                        serviceProvider.Object,
-                        mageCli.Object,
-                        manifestSigner.Object,
-                        logger.Object,
-                        fileMatcher.Object);
+                        signatureAlgorithmProvider,
+                        certificateProvider,
+                        serviceProvider,
+                        mageCli,
+                        manifestSigner,
+                        logger,
+                        fileMatcher);
 
                     signer.Retry = TimeSpan.FromMicroseconds(1);
 
@@ -340,26 +325,18 @@ namespace Sign.Core.Test
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
                 {
-                    Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-                    Mock<ICertificateProvider> certificateProvider = new();
+                    ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+                    ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+                    certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(certificate);
+                    signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(privateKey);
 
-                    certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(certificate);
-
-                    signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(privateKey);
-
-                    Mock<IServiceProvider> serviceProvider = new();
+                    IServiceProvider serviceProvider = Substitute.For<IServiceProvider>();
                     AggregatingSignerSpy aggregatingSignerSpy = new();
+                    serviceProvider.GetService(Arg.Any<Type>()).Returns(aggregatingSignerSpy);
 
-                    serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
-                        .Returns(aggregatingSignerSpy);
-
-                    Mock<IMageCli> mageCli = new();
+                    IMageCli mageCli = Substitute.For<IMageCli>();
                     string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\"";
-                    mageCli.Setup(x => x.RunAsync(
-                            It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
-                        .ReturnsAsync(0);
+                    mageCli.RunAsync(Arg.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))).Returns(0);
 
                     string publisher;
 
@@ -373,36 +350,20 @@ namespace Sign.Core.Test
                     }
 
                     expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\" -pub \"{publisher}\" -appm \"{manifestFile.FullName}\" -SupportURL https://description.test/";
-                    mageCli.Setup(x => x.RunAsync(
-                            It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
-                        .ReturnsAsync(0);
+                    mageCli.RunAsync(Arg.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))).Returns(0);
+                    mageCli.ClearReceivedCalls();
 
-                    Mock<IManifestSigner> manifestSigner = new();
-                    Mock<IFileMatcher> fileMatcher = new();
-
-                    manifestSigner.Setup(
-                        x => x.Sign(
-                            It.Is<FileInfo>(fi => fi.Name == manifestFile.Name),
-                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
-                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
-                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
-
-                    manifestSigner.Setup(
-                        x => x.Sign(
-                            It.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
-                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
-                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
-                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
-
-                    ILogger<IDataFormatSigner> logger = Mock.Of<ILogger<IDataFormatSigner>>();
+                    IManifestSigner manifestSigner = Substitute.For<IManifestSigner>();
+                    IFileMatcher fileMatcher = Substitute.For<IFileMatcher>();
+                    ILogger<IDataFormatSigner> logger = Substitute.For<ILogger<IDataFormatSigner>>();
                     ClickOnceSigner signer = new(
-                        signatureAlgorithmProvider.Object,
-                        certificateProvider.Object,
-                        serviceProvider.Object,
-                        mageCli.Object,
-                        manifestSigner.Object,
+                        signatureAlgorithmProvider,
+                        certificateProvider,
+                        serviceProvider,
+                        mageCli,
+                        manifestSigner,
                         logger,
-                        fileMatcher.Object);
+                        fileMatcher);
 
                     await signer.SignAsync(new[] { applicationFile }, options);
 
@@ -426,9 +387,26 @@ namespace Sign.Core.Test
                         file => Assert.Equal(
                             Path.Combine(jsonDeployFile.DirectoryName!, Path.GetFileNameWithoutExtension(jsonDeployFile.Name)),
                             file.FullName));
-
-                    mageCli.VerifyAll();
-                    manifestSigner.VerifyAll();
+                    await mageCli.Received(1).RunAsync(Arg.Is<string>(args => string.Equals(
+                        $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\"",
+                        args,
+                        StringComparison.Ordinal)));
+                    await mageCli.Received(1).RunAsync(Arg.Is<string>(args => string.Equals(
+                        $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\" -pub \"{publisher}\" -appm \"{manifestFile.FullName}\" -SupportURL https://description.test/",
+                        args,
+                        StringComparison.Ordinal)));
+                    manifestSigner.Received(1).Sign(
+                        Arg.Is<FileInfo>(fi => fi.Name == manifestFile.Name),
+                        Arg.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
+                        Arg.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
+                        Arg.Is<SignOptions>(o => ReferenceEquals(options, o)));
+                    manifestSigner.Received(1).Sign(
+                        Arg.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
+                        Arg.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
+                        Arg.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
+                        Arg.Is<SignOptions>(o => ReferenceEquals(options, o)));
+                    Assert.Equal(2, mageCli.ReceivedCalls().Count());
+                    Assert.Equal(2, manifestSigner.ReceivedCalls().Count());
                 }
             }
         }
@@ -466,22 +444,16 @@ namespace Sign.Core.Test
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
                 {
-                    Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-                    Mock<ICertificateProvider> certificateProvider = new();
+                    ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+                    ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+                    certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(certificate);
+                    signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(privateKey);
 
-                    certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(certificate);
-
-                    signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(privateKey);
-
-                    Mock<IServiceProvider> serviceProvider = new();
+                    IServiceProvider serviceProvider = Substitute.For<IServiceProvider>();
                     AggregatingSignerSpy aggregatingSignerSpy = new();
+                    serviceProvider.GetService(Arg.Any<Type>()).Returns(aggregatingSignerSpy);
 
-                    serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
-                        .Returns(aggregatingSignerSpy);
-
-                    Mock<IMageCli> mageCli = new();
+                    IMageCli mageCli = Substitute.For<IMageCli>();
 
                     string publisher;
 
@@ -495,29 +467,20 @@ namespace Sign.Core.Test
                     }
 
                     string expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\" -pub \"{publisher}\" -SupportURL https://description.test/";
-                    mageCli.Setup(x => x.RunAsync(
-                            It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
-                        .ReturnsAsync(0);
+                    mageCli.RunAsync(Arg.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))).Returns(0);
+                    mageCli.ClearReceivedCalls();
 
-                    Mock<IManifestSigner> manifestSigner = new();
-                    Mock<IFileMatcher> fileMatcher = new();
-
-                    manifestSigner.Setup(
-                        x => x.Sign(
-                            It.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
-                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
-                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
-                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
-
-                    ILogger<IDataFormatSigner> logger = Mock.Of<ILogger<IDataFormatSigner>>();
+                    IManifestSigner manifestSigner = Substitute.For<IManifestSigner>();
+                    IFileMatcher fileMatcher = Substitute.For<IFileMatcher>();
+                    ILogger<IDataFormatSigner> logger = Substitute.For<ILogger<IDataFormatSigner>>();
                     ClickOnceSigner signer = new(
-                        signatureAlgorithmProvider.Object,
-                        certificateProvider.Object,
-                        serviceProvider.Object,
-                        mageCli.Object,
-                        manifestSigner.Object,
+                        signatureAlgorithmProvider,
+                        certificateProvider,
+                        serviceProvider,
+                        mageCli,
+                        manifestSigner,
                         logger,
-                        fileMatcher.Object);
+                        fileMatcher);
 
                     await signer.SignAsync(new[] { applicationFile }, options);
 
@@ -530,9 +493,14 @@ namespace Sign.Core.Test
                     }
 
                     Assert.Empty(aggregatingSignerSpy.FilesSubmittedForSigning);
-
-                    mageCli.VerifyAll();
-                    manifestSigner.VerifyAll();
+                    await mageCli.Received(1).RunAsync(Arg.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal)));
+                    manifestSigner.Received(1).Sign(
+                        Arg.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
+                        Arg.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
+                        Arg.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
+                        Arg.Is<SignOptions>(o => ReferenceEquals(options, o)));
+                    Assert.Single(mageCli.ReceivedCalls());
+                    Assert.Single(manifestSigner.ReceivedCalls());
                 }
             }
         }
@@ -563,26 +531,20 @@ namespace Sign.Core.Test
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
                 {
-                    Mock<ISignatureAlgorithmProvider> signatureAlgorithmProvider = new();
-                    Mock<ICertificateProvider> certificateProvider = new();
+                    ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+                    ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+                    certificateProvider.GetCertificateAsync(Arg.Any<CancellationToken>()).Returns(certificate);
+                    signatureAlgorithmProvider.GetRsaAsync(Arg.Any<CancellationToken>()).Returns(privateKey);
 
-                    certificateProvider.Setup(x => x.GetCertificateAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(certificate);
-
-                    signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(privateKey);
-
-                    Mock<IServiceProvider> serviceProvider = new();
+                    IServiceProvider serviceProvider = Substitute.For<IServiceProvider>();
                     AggregatingSignerSpy aggregatingSignerSpy = new();
+                    serviceProvider.GetService(Arg.Any<Type>()).Returns(aggregatingSignerSpy);
 
-                    serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
-                        .Returns(aggregatingSignerSpy);
-
-                    Mock<IMageCli> mageCli = new();
+                    IMageCli mageCli = Substitute.For<IMageCli>();
                     string publisher = certificate.SubjectName.Name;
 
-                    Mock<IManifestSigner> manifestSigner = new();
-                    Mock<IFileMatcher> fileMatcher = new();
+                    IManifestSigner manifestSigner = Substitute.For<IManifestSigner>();
+                    IFileMatcher fileMatcher = Substitute.For<IFileMatcher>();
 
                     SignOptions options = new(
                         "ApplicationName",
@@ -597,22 +559,15 @@ namespace Sign.Core.Test
                         recurseContainers: true
                     );
 
-                    manifestSigner.Setup(
-                        x => x.Sign(
-                            It.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
-                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
-                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
-                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
-
-                    ILogger<IDataFormatSigner> logger = Mock.Of<ILogger<IDataFormatSigner>>();
+                    ILogger<IDataFormatSigner> logger = Substitute.For<ILogger<IDataFormatSigner>>();
                     ClickOnceSigner signer = new(
-                        signatureAlgorithmProvider.Object,
-                        certificateProvider.Object,
-                        serviceProvider.Object,
-                        mageCli.Object,
-                        manifestSigner.Object,
+                        signatureAlgorithmProvider,
+                        certificateProvider,
+                        serviceProvider,
+                        mageCli,
+                        manifestSigner,
                         logger,
-                        fileMatcher.Object);
+                        fileMatcher);
 
                     using (TemporaryDirectory signingDirectory = new(_directoryService))
                     {

--- a/test/Sign.Core.Test/DataFormatSigners/DefaultSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/DefaultSignerTests.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -59,26 +59,26 @@ namespace Sign.Core.Test
         [InlineData(false)]
         public void CanSign_WhenIAzureSignToolSignerIsAvailable_ReturnsTrue(bool expectedValue)
         {
-            Mock<IAzureSignToolDataFormatSigner> mock = new(MockBehavior.Strict);
-
-            mock.Setup(x => x.CanSign(It.IsAny<FileInfo>()))
-                .Returns(expectedValue);
+            FileInfo file = new("file.dll");
+            IAzureSignToolDataFormatSigner mock = Substitute.For<IAzureSignToolDataFormatSigner>();
+            mock.CanSign(Arg.Any<FileInfo>()).Returns(expectedValue);
+            mock.ClearReceivedCalls();
 
             IServiceCollection services = new ServiceCollection();
 
             services.AddLogging();
-            services.AddSingleton(Mock.Of<IToolConfigurationProvider>());
-            services.AddSingleton(Mock.Of<ISignatureAlgorithmProvider>());
-            services.AddSingleton(Mock.Of<ICertificateProvider>());
-            services.AddSingleton<IDataFormatSigner>(mock.Object);
+            services.AddSingleton(Substitute.For<IToolConfigurationProvider>());
+            services.AddSingleton(Substitute.For<ISignatureAlgorithmProvider>());
+            services.AddSingleton(Substitute.For<ICertificateProvider>());
+            services.AddSingleton<IDataFormatSigner>(mock);
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             DefaultSigner signer = new(serviceProvider);
 
-            Assert.Equal(expectedValue, signer.CanSign(new FileInfo("file.dll")));
-
-            mock.VerifyAll();
+            Assert.Equal(expectedValue, signer.CanSign(file));
+            mock.Received(1).CanSign(Arg.Is<FileInfo>(f => ReferenceEquals(f, file)));
+            Assert.Single(mock.ReceivedCalls());
         }
 
         [Fact]
@@ -106,26 +106,28 @@ namespace Sign.Core.Test
         [Fact]
         public async Task SignAsync_WhenIAzureSignToolSignerIsAvailable_InvokesInnerProvider()
         {
-            Mock<IAzureSignToolDataFormatSigner> mock = new(MockBehavior.Strict);
-
-            mock.Setup(x => x.SignAsync(It.IsAny<IEnumerable<FileInfo>>(), It.IsAny<SignOptions>()))
-                .Returns(Task.CompletedTask);
+            IEnumerable<FileInfo> files = [];
+            IAzureSignToolDataFormatSigner mock = Substitute.For<IAzureSignToolDataFormatSigner>();
+            mock.SignAsync(Arg.Any<IEnumerable<FileInfo>>(), Arg.Any<SignOptions>()).Returns(Task.CompletedTask);
+            mock.ClearReceivedCalls();
 
             IServiceCollection services = new ServiceCollection();
 
             services.AddLogging();
-            services.AddSingleton(Mock.Of<IToolConfigurationProvider>());
-            services.AddSingleton(Mock.Of<ISignatureAlgorithmProvider>());
-            services.AddSingleton(Mock.Of<ICertificateProvider>());
-            services.AddSingleton<IDataFormatSigner>(mock.Object);
+            services.AddSingleton(Substitute.For<IToolConfigurationProvider>());
+            services.AddSingleton(Substitute.For<ISignatureAlgorithmProvider>());
+            services.AddSingleton(Substitute.For<ICertificateProvider>());
+            services.AddSingleton<IDataFormatSigner>(mock);
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             DefaultSigner signer = new(serviceProvider);
 
-            await signer.SignAsync(Enumerable.Empty<FileInfo>(), _options);
-
-            mock.VerifyAll();
+            await signer.SignAsync(files, _options);
+            await mock.Received(1).SignAsync(
+                Arg.Is<IEnumerable<FileInfo>>(value => ReferenceEquals(value, files)),
+                Arg.Is<SignOptions>(value => ReferenceEquals(value, _options)));
+            Assert.Single(mock.ReceivedCalls());
         }
 
         private static DefaultSigner CreateWithoutAzureSignTool()
@@ -141,9 +143,9 @@ namespace Sign.Core.Test
             IServiceCollection services = new ServiceCollection();
 
             services.AddLogging();
-            services.AddSingleton(Mock.Of<IToolConfigurationProvider>());
-            services.AddSingleton(Mock.Of<ISignatureAlgorithmProvider>());
-            services.AddSingleton(Mock.Of<ICertificateProvider>());
+            services.AddSingleton(Substitute.For<IToolConfigurationProvider>());
+            services.AddSingleton(Substitute.For<ISignatureAlgorithmProvider>());
+            services.AddSingleton(Substitute.For<ICertificateProvider>());
             services.AddSingleton<IDataFormatSigner, AzureSignToolSigner>();
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();

--- a/test/Sign.Core.Test/DataFormatSigners/DynamicsBusinessCentralAppFileTypeTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/DynamicsBusinessCentralAppFileTypeTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -15,7 +15,7 @@ namespace Sign.Core.Test
 
         public DynamicsBusinessCentralAppFileTypeTests()
         {
-            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _directoryService = new DirectoryService(Substitute.For<ILogger<IDirectoryService>>());
             _fileType = new DynamicsBusinessCentralAppFileType();
             _temporaryDirectory = new TemporaryDirectory(_directoryService);
         }

--- a/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
@@ -17,10 +17,10 @@ namespace Sign.Core.Test
         public NuGetSignerTests()
         {
             _signer = new NuGetSigner(
-                Mock.Of<ISignatureAlgorithmProvider>(),
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<INuGetSignTool>(),
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<ISignatureAlgorithmProvider>(),
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<INuGetSignTool>(),
+                Substitute.For<ILogger<IDataFormatSigner>>());
         }
 
         [Fact]
@@ -29,9 +29,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetSigner(
                     signatureAlgorithmProvider: null!,
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<INuGetSignTool>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<INuGetSignTool>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("signatureAlgorithmProvider", exception.ParamName);
         }
@@ -41,10 +41,10 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
                     certificateProvider: null!,
-                    Mock.Of<INuGetSignTool>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<INuGetSignTool>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
         }
@@ -54,10 +54,10 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
                     nuGetSignTool: null!,
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("nuGetSignTool", exception.ParamName);
         }
@@ -67,9 +67,9 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new NuGetSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<INuGetSignTool>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<INuGetSignTool>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
@@ -106,21 +106,19 @@ namespace Sign.Core.Test
         [Fact]
         public async Task SignAsync_WhenSigningFails_Throws()
         {
-            Mock<INuGetSignTool> nuGetSignTool = new();
-
-            nuGetSignTool.Setup(
-                x => x.SignAsync(
-                    It.IsNotNull<FileInfo>(),
-                    It.IsNotNull<RSA>(),
-                    It.IsNotNull<X509Certificate2>(),
-                    It.IsNotNull<SignOptions>()))
-                .Returns(Task.FromResult(false));
+            INuGetSignTool nuGetSignTool = Substitute.For<INuGetSignTool>();
+            nuGetSignTool.SignAsync(
+                    Arg.Any<FileInfo>(),
+                    Arg.Any<RSA>(),
+                    Arg.Any<X509Certificate2>(),
+                    Arg.Any<SignOptions>())
+                .Returns(false);
 
             NuGetSigner signer = new(
-                Mock.Of<ISignatureAlgorithmProvider>(),
-                Mock.Of<ICertificateProvider>(),
-                nuGetSignTool.Object,
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<ISignatureAlgorithmProvider>(),
+                Substitute.For<ICertificateProvider>(),
+                nuGetSignTool,
+                Substitute.For<ILogger<IDataFormatSigner>>());
 
             signer.Retry = TimeSpan.FromMicroseconds(1);
 
@@ -136,7 +134,7 @@ namespace Sign.Core.Test
                 antiMatcher: null,
                 recurseContainers: true);
 
-            using (DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>()))
+            using (DirectoryService directoryService = new(Substitute.For<ILogger<IDirectoryService>>()))
             using (TemporaryDirectory temporaryDirectory = new(directoryService))
             {
                 FileInfo nupkgFile = TestFileCreator.CreateEmptyZipFile(temporaryDirectory, fileExtension: ".nupkg");

--- a/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
@@ -108,10 +108,10 @@ namespace Sign.Core.Test
         {
             INuGetSignTool nuGetSignTool = Substitute.For<INuGetSignTool>();
             nuGetSignTool.SignAsync(
-            Arg.Is<FileInfo>(value => value != null),
-            Arg.Is<RSA>(value => value != null),
-            Arg.Is<X509Certificate2>(value => value != null),
-            Arg.Is<SignOptions>(value => value != null))
+                    Arg.Is<FileInfo>(value => value != null),
+                    Arg.Is<RSA>(value => value != null),
+                    Arg.Is<X509Certificate2>(value => value != null),
+                    Arg.Is<SignOptions>(value => value != null))
                 .Returns(false);
 
             NuGetSigner signer = new(

--- a/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
@@ -108,10 +108,10 @@ namespace Sign.Core.Test
         {
             INuGetSignTool nuGetSignTool = Substitute.For<INuGetSignTool>();
             nuGetSignTool.SignAsync(
-                    Arg.Any<FileInfo>(),
-                    Arg.Any<RSA>(),
-                    Arg.Any<X509Certificate2>(),
-                    Arg.Any<SignOptions>())
+            Arg.Is<FileInfo>(value => value != null),
+            Arg.Is<RSA>(value => value != null),
+            Arg.Is<X509Certificate2>(value => value != null),
+            Arg.Is<SignOptions>(value => value != null))
                 .Returns(false);
 
             NuGetSigner signer = new(

--- a/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
@@ -17,10 +17,10 @@ namespace Sign.Core.Test
         public VsixSignerTests()
         {
             _signer = new VsixSigner(
-                Mock.Of<ISignatureAlgorithmProvider>(),
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<IVsixSignTool>(),
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<ISignatureAlgorithmProvider>(),
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<IVsixSignTool>(),
+                Substitute.For<ILogger<IDataFormatSigner>>());
         }
 
         [Fact]
@@ -29,9 +29,9 @@ namespace Sign.Core.Test
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new VsixSigner(
                     signatureAlgorithmProvider: null!,
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IVsixSignTool>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IVsixSignTool>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("signatureAlgorithmProvider", exception.ParamName);
         }
@@ -41,10 +41,10 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new VsixSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
                     certificateProvider: null!,
-                    Mock.Of<IVsixSignTool>(),
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<IVsixSignTool>(),
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
         }
@@ -54,10 +54,10 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new VsixSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
                     vsixSignTool: null!,
-                    Mock.Of<ILogger<IDataFormatSigner>>()));
+                    Substitute.For<ILogger<IDataFormatSigner>>()));
 
             Assert.Equal("vsixSignTool", exception.ParamName);
         }
@@ -67,9 +67,9 @@ namespace Sign.Core.Test
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => new VsixSigner(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IVsixSignTool>(),
+                    Substitute.For<ISignatureAlgorithmProvider>(),
+                    Substitute.For<ICertificateProvider>(),
+                    Substitute.For<IVsixSignTool>(),
                     logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
@@ -120,7 +120,7 @@ namespace Sign.Core.Test
                 antiMatcher: null,
                 recurseContainers: true);
 
-            using (DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>()))
+            using (DirectoryService directoryService = new(Substitute.For<ILogger<IDirectoryService>>()))
             using (TemporaryDirectory temporaryDirectory = new(directoryService))
             {
                 FileInfo vsixFile = TestFileCreator.CreateEmptyZipFile(temporaryDirectory, fileExtension: ".vsix");
@@ -128,7 +128,7 @@ namespace Sign.Core.Test
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
                 {
-                    Mock<IVsixSignTool> vsixSignTool = new();
+                    IVsixSignTool vsixSignTool = Substitute.For<IVsixSignTool>();
 
                     SignConfigurationSet configuration = new(
                         options.FileHashAlgorithm,
@@ -136,18 +136,17 @@ namespace Sign.Core.Test
                         privateKey,
                         certificate);
 
-                    vsixSignTool.Setup(
-                        x => x.SignAsync(
-                            It.IsNotNull<FileInfo>(),
-                            It.IsNotNull<SignConfigurationSet>(),
-                            It.IsNotNull<SignOptions>()))
-                        .Returns(Task.FromResult(false));
+                    vsixSignTool.SignAsync(
+                            Arg.Any<FileInfo>(),
+                            Arg.Any<SignConfigurationSet>(),
+                            Arg.Any<SignOptions>())
+                        .Returns(false);
 
                     VsixSigner signer = new(
-                        Mock.Of<ISignatureAlgorithmProvider>(),
-                        Mock.Of<ICertificateProvider>(),
-                        vsixSignTool.Object,
-                        Mock.Of<ILogger<IDataFormatSigner>>());
+                        Substitute.For<ISignatureAlgorithmProvider>(),
+                        Substitute.For<ICertificateProvider>(),
+                        vsixSignTool,
+                        Substitute.For<ILogger<IDataFormatSigner>>());
 
                     signer.Retry = TimeSpan.FromMicroseconds(1);
 

--- a/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
@@ -137,9 +137,9 @@ namespace Sign.Core.Test
                         certificate);
 
                     vsixSignTool.SignAsync(
-                            Arg.Any<FileInfo>(),
-                            Arg.Any<SignConfigurationSet>(),
-                            Arg.Any<SignOptions>())
+                            Arg.Is<FileInfo>(value => value != null),
+                            Arg.Is<SignConfigurationSet>(value => value != null),
+                            Arg.Is<SignOptions>(value => value != null))
                         .Returns(false);
 
                     VsixSigner signer = new(

--- a/test/Sign.Core.Test/FileSystem/DirectoryServiceTests.cs
+++ b/test/Sign.Core.Test/FileSystem/DirectoryServiceTests.cs
@@ -1,19 +1,19 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
     public class DirectoryServiceTests
     {
-        private readonly Mock<ILogger<IDirectoryService>> _loggerMock;
+        private readonly ILogger<IDirectoryService> _logger;
 
         public DirectoryServiceTests()
         {
-            _loggerMock = new Mock<ILogger<IDirectoryService>>();
+            _logger = Substitute.For<ILogger<IDirectoryService>>();
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace Sign.Core.Test
         [Fact]
         public void CreateTemporaryDirectory_Always_CreatesDirectory()
         {
-            using (DirectoryService service = new(_loggerMock.Object))
+            using (DirectoryService service = new(_logger))
             {
                 DirectoryInfo directory = service.CreateTemporaryDirectory();
 
@@ -43,7 +43,7 @@ namespace Sign.Core.Test
         [Fact]
         public void Delete_WhenDirectoryIsNull_Throws()
         {
-            using (DirectoryService service = new(_loggerMock.Object))
+            using (DirectoryService service = new(_logger))
             {
                 ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                     () => service.Delete(directory: null!));
@@ -55,7 +55,7 @@ namespace Sign.Core.Test
         [Fact]
         public void Delete_Always_DeletesDirectory()
         {
-            using (DirectoryService service = new(_loggerMock.Object))
+            using (DirectoryService service = new(_logger))
             {
                 DirectoryInfo directory = service.CreateTemporaryDirectory();
 
@@ -73,7 +73,7 @@ namespace Sign.Core.Test
         {
             DirectoryInfo directory;
 
-            using (DirectoryService service = new(_loggerMock.Object))
+            using (DirectoryService service = new(_logger))
             {
                 directory = service.CreateTemporaryDirectory();
 

--- a/test/Sign.Core.Test/ServiceProviderTests.cs
+++ b/test/Sign.Core.Test/ServiceProviderTests.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -27,8 +27,8 @@ namespace Sign.Core.Test
                 {
                     // Dependency injection of some services require these services.
                     // Normally, these services are added at runtime in the CLI.
-                    services.AddSingleton<ISignatureAlgorithmProvider>(Mock.Of<ISignatureAlgorithmProvider>());
-                    services.AddSingleton<ICertificateProvider>(Mock.Of<ICertificateProvider>());
+                    services.AddSingleton<ISignatureAlgorithmProvider>(Substitute.For<ISignatureAlgorithmProvider>());
+                    services.AddSingleton<ICertificateProvider>(Substitute.For<ICertificateProvider>());
                 });
 
             // Start of tests

--- a/test/Sign.Core.Test/Sign.Core.Test.csproj
+++ b/test/Sign.Core.Test/Sign.Core.Test.csproj
@@ -14,7 +14,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" PrivateAssets="all" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <IncludeAssets>analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="AzureSign.Core">
       <IncludeAssets>compile;runtime</IncludeAssets>
     </PackageReference>

--- a/test/Sign.Core.Test/SignerTests.cs
+++ b/test/Sign.Core.Test/SignerTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
@@ -13,7 +13,7 @@ using System.Xml;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualBasic;
-using Moq;
+using NSubstitute;
 using NuGet.Packaging;
 using Sign.TestInfrastructure;
 
@@ -33,7 +33,7 @@ namespace Sign.Core.Test
 
             _certificatesFixture = certificatesFixture;
             _keyVaultServiceStub = new KeyVaultServiceStub();
-            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _directoryService = new DirectoryService(Substitute.For<ILogger<IDirectoryService>>());
             _temporaryDirectory = new TemporaryDirectory(_directoryService);
         }
 
@@ -48,7 +48,7 @@ namespace Sign.Core.Test
         public void Constructor_WhenServiceProviderIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new Signer(serviceProvider: null!, Mock.Of<ILogger<ISigner>>()));
+                () => new Signer(serviceProvider: null!, Substitute.For<ILogger<ISigner>>()));
 
             Assert.Equal("serviceProvider", exception.ParamName);
         }
@@ -57,7 +57,7 @@ namespace Sign.Core.Test
         public void Constructor_WhenLoggerIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new Signer(Mock.Of<IServiceProvider>(), logger: null!));
+                () => new Signer(Substitute.For<IServiceProvider>(), logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }

--- a/test/Sign.Core.Test/TestInfrastructure/AggregatingSignerTest.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/AggregatingSignerTest.cs
@@ -1,10 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -85,10 +85,10 @@ namespace Sign.Core.Test
 
             HashSet<FileInfo> looseFiles = new(FileInfoComparer.Instance);
             AzureSignToolSigner azureSignToolSigner = new(
-                Mock.Of<IToolConfigurationProvider>(),
-                Mock.Of<ISignatureAlgorithmProvider>(),
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<ILogger<IDataFormatSigner>>());
+                Substitute.For<IToolConfigurationProvider>(),
+                Substitute.For<ISignatureAlgorithmProvider>(),
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<ILogger<IDataFormatSigner>>());
             FileMetadataServiceStub fileMetadataService = new();
 
             // This directory doesn't actually exist or even need to exist.

--- a/test/Sign.Core.Test/TestInfrastructure/ContainerProviderStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/ContainerProviderStub.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -16,11 +16,11 @@ namespace Sign.Core.Test
         internal ContainerProviderStub()
         {
             _containerProvider = new ContainerProvider(
-                Mock.Of<ICertificateProvider>(),
-                Mock.Of<IDirectoryService>(),
-                Mock.Of<IFileMatcher>(),
-                Mock.Of<IMakeAppxCli>(),
-                Mock.Of<ILogger<IContainerProvider>>());
+                Substitute.For<ICertificateProvider>(),
+                Substitute.For<IDirectoryService>(),
+                Substitute.For<IFileMatcher>(),
+                Substitute.For<IMakeAppxCli>(),
+                Substitute.For<ILogger<IContainerProvider>>());
         }
 
         public bool IsAppxBundleContainer(FileInfo file)

--- a/test/Sign.Core.Test/TestInfrastructure/Server/PfxFilesFixture.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/PfxFilesFixture.cs
@@ -6,7 +6,7 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -18,7 +18,7 @@ namespace Sign.Core.Test
 
         public PfxFilesFixture()
         {
-            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _directoryService = new DirectoryService(Substitute.For<ILogger<IDirectoryService>>());
             _directory = new TemporaryDirectory(_directoryService);
             _pfxFiles = new ConcurrentDictionary<Tuple<int, HashAlgorithmName>, FileInfo>();
         }

--- a/test/Sign.Core.Test/TestInfrastructure/Server/TimestampService.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/TimestampService.cs
@@ -1,4 +1,4 @@
-#pragma warning disable IDE0073
+﻿#pragma warning disable IDE0073
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
@@ -9,7 +9,7 @@ using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -48,7 +48,7 @@ namespace Sign.Core.Test
             Certificate = certificate;
             Url = uri;
             _nextSerialNumber = BigInteger.One;
-            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _directoryService = new DirectoryService(Substitute.For<ILogger<IDirectoryService>>());
             _temporaryDirectory = new TemporaryDirectory(_directoryService);
         }
 

--- a/test/Sign.Core.Test/TestInfrastructure/SignerSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/SignerSpy.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 
 namespace Sign.Core.Test
 {
@@ -21,16 +21,16 @@ namespace Sign.Core.Test
 
         internal SignerSpy()
         {
-            ISignatureAlgorithmProvider signatureAlgorithmProvider = Mock.Of<ISignatureAlgorithmProvider>();
-            ICertificateProvider certificateProvider = Mock.Of<ICertificateProvider>();
-            ILogger<IDataFormatSigner> logger = Mock.Of<ILogger<IDataFormatSigner>>();
-            IMageCli mageCli = Mock.Of<IMageCli>();
-            IManifestSigner manifestSigner = Mock.Of<IManifestSigner>();
-            INuGetSignTool nuGetSignTool = Mock.Of<INuGetSignTool>();
-            IVsixSignTool openVsixSignTool = Mock.Of<IVsixSignTool>();
-            IServiceProvider serviceProvider = Mock.Of<IServiceProvider>();
-            IToolConfigurationProvider toolConfigurationProvider = Mock.Of<IToolConfigurationProvider>();
-            IFileMatcher fileMatcher = Mock.Of<IFileMatcher>();
+            ISignatureAlgorithmProvider signatureAlgorithmProvider = Substitute.For<ISignatureAlgorithmProvider>();
+            ICertificateProvider certificateProvider = Substitute.For<ICertificateProvider>();
+            ILogger<IDataFormatSigner> logger = Substitute.For<ILogger<IDataFormatSigner>>();
+            IMageCli mageCli = Substitute.For<IMageCli>();
+            IManifestSigner manifestSigner = Substitute.For<IManifestSigner>();
+            INuGetSignTool nuGetSignTool = Substitute.For<INuGetSignTool>();
+            IVsixSignTool openVsixSignTool = Substitute.For<IVsixSignTool>();
+            IServiceProvider serviceProvider = Substitute.For<IServiceProvider>();
+            IToolConfigurationProvider toolConfigurationProvider = Substitute.For<IToolConfigurationProvider>();
+            IFileMatcher fileMatcher = Substitute.For<IFileMatcher>();
 
             Signer = new AzureSignToolSigner(
                 toolConfigurationProvider,

--- a/test/Sign.SignatureProviders.ArtifactSigning.Test/RSATrustedSigningTests.cs
+++ b/test/Sign.SignatureProviders.ArtifactSigning.Test/RSATrustedSigningTests.cs
@@ -167,7 +167,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
             _client.Received(1).StartSign(
                 AccountName,
                 CertificateProfileName,
-                Arg.Is<SignRequest>(request => request.SignatureAlgorithm == expectedSignatureAlgorithm && ReferenceEquals(request.Digest, hash)),
+                Arg.Is<SignRequest>(request => request != null && request.SignatureAlgorithm == expectedSignatureAlgorithm && ReferenceEquals(request.Digest, hash)),
                 null,
                 null,
                 null,

--- a/test/Sign.SignatureProviders.ArtifactSigning.Test/RSATrustedSigningTests.cs
+++ b/test/Sign.SignatureProviders.ArtifactSigning.Test/RSATrustedSigningTests.cs
@@ -71,7 +71,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
             RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, rsaPublicKey);
             rsa.Dispose();
 
-            Assert.True(rsaPublicKey.Disposed);
+            Assert.Equal(1, rsaPublicKey.DisposeTrueCallCount);
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
             CertificateProfileSignOperation operation = Substitute.For<CertificateProfileSignOperation>();
 
             operation
-                .WaitForCompletion(Arg.Any<CancellationToken>())
+                .WaitForCompletion(default)
                 .Returns(response);
 
             _client
@@ -191,11 +191,15 @@ namespace Sign.SignatureProviders.KeyVault.Test
 
         private sealed class RecordingRSA : RSA
         {
-            internal bool Disposed { get; private set; }
+            internal int DisposeTrueCallCount { get; private set; }
 
             protected override void Dispose(bool disposing)
             {
-                Disposed = disposing;
+                if (disposing)
+                {
+                    DisposeTrueCallCount++;
+                }
+
                 base.Dispose(disposing);
             }
 

--- a/test/Sign.SignatureProviders.ArtifactSigning.Test/RSATrustedSigningTests.cs
+++ b/test/Sign.SignatureProviders.ArtifactSigning.Test/RSATrustedSigningTests.cs
@@ -6,8 +6,7 @@ using System.Security.Cryptography;
 using Azure;
 using Azure.CodeSigning;
 using Azure.CodeSigning.Models;
-using Moq;
-using Moq.Protected;
+using NSubstitute;
 using Sign.SignatureProviders.ArtifactSigning;
 
 namespace Sign.SignatureProviders.KeyVault.Test
@@ -17,14 +16,14 @@ namespace Sign.SignatureProviders.KeyVault.Test
         private static readonly string AccountName = "testAccount";
         private static readonly string CertificateProfileName = "testProfile";
 
-        private readonly Mock<CertificateProfileClient> _client = new();
-        private readonly Mock<RSA> _rsaPublicKey = new();
+        private readonly CertificateProfileClient _client = Substitute.For<CertificateProfileClient>();
+        private readonly RSA _rsaPublicKey = Substitute.For<RSA>();
 
         [Fact]
         public void Constructor_WhenClientIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new RSAArtifactSigning(client: null!, AccountName, CertificateProfileName, _rsaPublicKey.Object));
+                () => new RSAArtifactSigning(client: null!, AccountName, CertificateProfileName, _rsaPublicKey));
 
             Assert.Equal("client", exception.ParamName);
         }
@@ -33,7 +32,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenAccountNameIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new RSAArtifactSigning(_client.Object, accountName: null!, CertificateProfileName, _rsaPublicKey.Object));
+                () => new RSAArtifactSigning(_client, accountName: null!, CertificateProfileName, _rsaPublicKey));
 
             Assert.Equal("accountName", exception.ParamName);
         }
@@ -42,7 +41,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenAccountNameIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new RSAArtifactSigning(_client.Object, accountName: string.Empty, CertificateProfileName, _rsaPublicKey.Object));
+                () => new RSAArtifactSigning(_client, accountName: string.Empty, CertificateProfileName, _rsaPublicKey));
 
             Assert.Equal("accountName", exception.ParamName);
         }
@@ -51,7 +50,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateProfileNameIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new RSAArtifactSigning(_client.Object, AccountName, certificateProfileName: null!, _rsaPublicKey.Object));
+                () => new RSAArtifactSigning(_client, AccountName, certificateProfileName: null!, _rsaPublicKey));
 
             Assert.Equal("certificateProfileName", exception.ParamName);
         }
@@ -60,7 +59,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateProfileNameIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new RSAArtifactSigning(_client.Object, AccountName, certificateProfileName: string.Empty, _rsaPublicKey.Object));
+                () => new RSAArtifactSigning(_client, AccountName, certificateProfileName: string.Empty, _rsaPublicKey));
 
             Assert.Equal("certificateProfileName", exception.ParamName);
         }
@@ -68,16 +67,17 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [Fact]
         public void Dispose_DisposesRSAKeyVaultAndRSAPublicKey()
         {
-            RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            RecordingRSA rsaPublicKey = new();
+            RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, rsaPublicKey);
             rsa.Dispose();
 
-            _rsaPublicKey.Protected().Verify(nameof(RSA.Dispose), Times.Once(), [true]);
+            Assert.True(rsaPublicKey.Disposed);
         }
 
         [Fact]
         public void ExportParameters_IncludePrivateParametersIsTrue_Throws()
         {
-            using RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            using RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, _rsaPublicKey);
 
             Assert.Throws<NotSupportedException>(
                 () => rsa.ExportParameters(true));
@@ -86,17 +86,17 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [Fact]
         public void ExportParameters_IncludePrivateParametersIsFalse_UsesExportParametersOfPublicKey()
         {
-            using RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            using RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, _rsaPublicKey);
 
             rsa.ExportParameters(false);
 
-            _rsaPublicKey.Verify(_ => _.ExportParameters(false), Times.Once());
+            _rsaPublicKey.Received(1).ExportParameters(false);
         }
 
         [Fact]
         public void ImportParameters_Throws()
         {
-            using RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            using RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, _rsaPublicKey);
 
             Assert.Throws<NotImplementedException>(
                 () => rsa.ImportParameters(default));
@@ -105,7 +105,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [Fact]
         public void SignHash_InvalidHashLength_Throws()
         {
-            using RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            using RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, _rsaPublicKey);
 
             byte[] hash = [];
             HashAlgorithmName hashAlgorithmName = HashAlgorithmName.SHA256;
@@ -124,7 +124,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [InlineData(64, nameof(RSASignaturePadding.Pss), nameof(SignatureAlgorithm.PS512))]
         public void SignHash_UsesClient(int hashLength, string paddingName, string expectedSignatureAlgorithmName)
         {
-            using RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            using RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, _rsaPublicKey);
 
             RSASignaturePadding padding = paddingName switch
             {
@@ -147,38 +147,37 @@ namespace Sign.SignatureProviders.KeyVault.Test
             byte[] signature = [];
             byte[] hash = new byte[hashLength];
             HashAlgorithmName hashAlgorithmName = HashAlgorithmName.SHA256;
-            Mock<Response<SignStatus>> response = new();
-            Mock<CertificateProfileSignOperation> operation = new();
-
-            response
-                .SetupGet(_ => _.Value)
-                    .Returns(new SignStatus(Guid.NewGuid(), Status.Succeeded, signature, []));
+            Response<SignStatus> response = Response.FromValue(
+                new SignStatus(Guid.NewGuid(), Status.Succeeded, signature, []),
+                Substitute.For<Response>());
+            CertificateProfileSignOperation operation = Substitute.For<CertificateProfileSignOperation>();
 
             operation
-                .Setup(_ => _.WaitForCompletion(default))
-                .Returns(response.Object);
+                .WaitForCompletion(Arg.Any<CancellationToken>())
+                .Returns(response);
 
-            _client.Setup(_ => _.StartSign(AccountName, CertificateProfileName, It.IsAny<SignRequest>(), null, null, null, default))
-                    .Returns(operation.Object);
+            _client
+                .StartSign(AccountName, CertificateProfileName, Arg.Any<SignRequest>(), null, null, null, default)
+                .Returns(operation);
 
             var result = rsa.SignHash(hash, hashAlgorithmName, padding);
 
             Assert.Same(signature, result);
 
-            _client.Verify(_ => _.StartSign(
+            _client.Received(1).StartSign(
                 AccountName,
                 CertificateProfileName,
-                It.Is<SignRequest>(request => request.SignatureAlgorithm == expectedSignatureAlgorithm && ReferenceEquals(request.Digest, hash)),
+                Arg.Is<SignRequest>(request => request.SignatureAlgorithm == expectedSignatureAlgorithm && ReferenceEquals(request.Digest, hash)),
                 null,
                 null,
                 null,
-                default), Times.Once());
+                default);
         }
 
         [Fact]
         public void VerifyHash_UsesPublicKey()
         {
-            using RSAArtifactSigning rsa = new(_client.Object, AccountName, CertificateProfileName, _rsaPublicKey.Object);
+            using RSAArtifactSigning rsa = new(_client, AccountName, CertificateProfileName, _rsaPublicKey);
 
             byte[] hash = [];
             byte[] signature = [];
@@ -187,7 +186,24 @@ namespace Sign.SignatureProviders.KeyVault.Test
 
             rsa.VerifyHash(hash, signature, hashAlgorithmName, padding);
 
-            _rsaPublicKey.Verify(_ => _.VerifyHash(hash, signature, hashAlgorithmName, padding), Times.Once());
+            _rsaPublicKey.Received(1).VerifyHash(hash, signature, hashAlgorithmName, padding);
+        }
+
+        private sealed class RecordingRSA : RSA
+        {
+            internal bool Disposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = disposing;
+                base.Dispose(disposing);
+            }
+
+            public override RSAParameters ExportParameters(bool includePrivateParameters) => default;
+
+            public override void ImportParameters(RSAParameters parameters)
+            {
+            }
         }
     }
 }

--- a/test/Sign.SignatureProviders.ArtifactSigning.Test/Sign.SignatureProviders.ArtifactSigning.Test.csproj
+++ b/test/Sign.SignatureProviders.ArtifactSigning.Test/Sign.SignatureProviders.ArtifactSigning.Test.csproj
@@ -12,7 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" PrivateAssets="all" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <IncludeAssets>analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sign.SignatureProviders.ArtifactSigning.Test/TrustedSigningServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.ArtifactSigning.Test/TrustedSigningServiceProviderTests.cs
@@ -5,7 +5,7 @@
 using Azure.CodeSigning;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.SignatureProviders.ArtifactSigning.Test
@@ -22,7 +22,7 @@ namespace Sign.SignatureProviders.ArtifactSigning.Test
             services.AddSingleton<ArtifactSigningService>(sp =>
             {
                 return new ArtifactSigningService(
-                     Mock.Of<CertificateProfileClient>(),
+                     Substitute.For<CertificateProfileClient>(),
                      "account",
                      "profile",
                      sp.GetRequiredService<ILogger<ArtifactSigningService>>());

--- a/test/Sign.SignatureProviders.ArtifactSigning.Test/TrustedSigningServiceTests.cs
+++ b/test/Sign.SignatureProviders.ArtifactSigning.Test/TrustedSigningServiceTests.cs
@@ -4,17 +4,17 @@
 
 using Azure.CodeSigning;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.SignatureProviders.ArtifactSigning;
 
 namespace Sign.SignatureProviders.TrustedSigning.Test
 {
     public class TrustedSigningServiceTests
     {
-        private static readonly CertificateProfileClient CertificateProfileClient = Mock.Of<CertificateProfileClient>();
+        private static readonly CertificateProfileClient CertificateProfileClient = Substitute.For<CertificateProfileClient>();
         private const string AccountName = "a";
         private const string CertificateProfileName = "b";
-        private static readonly ILogger<ArtifactSigningService> Logger = Mock.Of<ILogger<ArtifactSigningService>>();
+        private static readonly ILogger<ArtifactSigningService> Logger = Substitute.For<ILogger<ArtifactSigningService>>();
 
         [Fact]
         public void Constructor_WhenCertificateProfileClientIsNull_Throws()

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
@@ -6,7 +6,7 @@ using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.SignatureProviders.KeyVault.Test
@@ -23,8 +23,8 @@ namespace Sign.SignatureProviders.KeyVault.Test
             services.AddSingleton<KeyVaultService>(sp =>
             {
                 return new KeyVaultService(
-                    Mock.Of<CertificateClient>(),
-                    Mock.Of<CryptographyClient>(),
+                    Substitute.For<CertificateClient>(),
+                    Substitute.For<CryptographyClient>(),
                     "a", sp.GetRequiredService<ILogger<KeyVaultService>>());
             });
             serviceProvider = services.BuildServiceProvider();

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
@@ -8,7 +8,7 @@ using Azure;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Sign.TestInfrastructure;
 
 namespace Sign.SignatureProviders.KeyVault.Test
@@ -16,16 +16,16 @@ namespace Sign.SignatureProviders.KeyVault.Test
     public class KeyVaultServiceTests
     {
         private const string CertificateName = "a";
-        private static readonly ILogger<KeyVaultService> Logger = Mock.Of<ILogger<KeyVaultService>>();
+        private static readonly ILogger<KeyVaultService> Logger = Substitute.For<ILogger<KeyVaultService>>();
 
-        private readonly Mock<CertificateClient> _certificateClient = new();
-        private readonly Mock<CryptographyClient> _cryptographyClient = new();
+        private readonly CertificateClient _certificateClient = Substitute.For<CertificateClient>();
+        private readonly CryptographyClient _cryptographyClient = Substitute.For<CryptographyClient>();
 
         [Fact]
         public void Constructor_WhenCertificateClientIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(certificateClient: null!, _cryptographyClient.Object, CertificateName, Logger));
+                () => new KeyVaultService(certificateClient: null!, _cryptographyClient, CertificateName, Logger));
 
             Assert.Equal("certificateClient", exception.ParamName);
         }
@@ -34,7 +34,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCryptographyClientIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(_certificateClient.Object, cryptographyClient: null!, CertificateName, Logger));
+                () => new KeyVaultService(_certificateClient, cryptographyClient: null!, CertificateName, Logger));
 
             Assert.Equal("cryptographyClient", exception.ParamName);
         }
@@ -43,7 +43,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateNameIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, certificateName: null!, Logger));
+                () => new KeyVaultService(_certificateClient, _cryptographyClient, certificateName: null!, Logger));
 
             Assert.Equal("certificateName", exception.ParamName);
         }
@@ -52,7 +52,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateNameIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, certificateName: string.Empty, Logger));
+                () => new KeyVaultService(_certificateClient, _cryptographyClient, certificateName: string.Empty, Logger));
 
             Assert.Equal("certificateName", exception.ParamName);
         }
@@ -61,7 +61,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenLoggerIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, CertificateName, logger: null!));
+                () => new KeyVaultService(_certificateClient, _cryptographyClient, CertificateName, logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -70,65 +70,60 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public async Task GetCertificateAsync_CalledTwice_CertificateRetrievedOnce()
         {
             CancellationToken cancellationToken = CancellationToken.None;
-            Mock<KeyVaultCertificateWithPolicy> certificate = CreateMockKeyVaultCertificateWithPolicy();
-            Mock<Response<KeyVaultCertificateWithPolicy>> response = new();
-
-            response
-                .Setup(_ => _.Value)
-                .Returns(certificate.Object);
+            KeyVaultCertificateWithPolicy certificate = CreateKeyVaultCertificateWithPolicy();
+            Response<KeyVaultCertificateWithPolicy> response = Response.FromValue(certificate, Substitute.For<Response>());
 
             _certificateClient
-                .Setup(_ => _.GetCertificateAsync(CertificateName, cancellationToken))
-                .ReturnsAsync(response.Object);
+                .GetCertificateAsync(CertificateName, cancellationToken)
+                .Returns(response);
 
-            using KeyVaultService service = new(_certificateClient.Object, _cryptographyClient.Object, CertificateName, Logger);
+            using KeyVaultService service = new(_certificateClient, _cryptographyClient, CertificateName, Logger);
 
             using X509Certificate2 certificate1 = await service.GetCertificateAsync(cancellationToken);
             using X509Certificate2 certificate2 = await service.GetCertificateAsync(cancellationToken);
 
-            _certificateClient.Verify(_ => _.GetCertificateAsync(CertificateName, cancellationToken), Times.Once);
+            await _certificateClient.Received(1).GetCertificateAsync(CertificateName, cancellationToken);
         }
 
         [Fact]
         public async Task GetRsaAsync_ReturnsRSAKeyVaultWrapper()
         {
             CancellationToken cancellationToken = CancellationToken.None;
-            Mock<KeyVaultCertificateWithPolicy> certificate = CreateMockKeyVaultCertificateWithPolicy();
-            Mock<RSAKeyVault> rsaKeyVault = new(Mock.Of<CryptographyClient>(), "testId", null);
-            Mock<Response<KeyVaultCertificateWithPolicy>> response = new();
-
-            response
-                .Setup(_ => _.Value)
-                .Returns(certificate.Object);
+            KeyVaultCertificateWithPolicy certificate = CreateKeyVaultCertificateWithPolicy();
+            RSAKeyVault rsaKeyVault = CreateRSAKeyVault();
+            Response<KeyVaultCertificateWithPolicy> response = Response.FromValue(certificate, Substitute.For<Response>());
 
             _certificateClient
-                .Setup(_ => _.GetCertificateAsync(CertificateName, cancellationToken))
-                .ReturnsAsync(response.Object);
+                .GetCertificateAsync(CertificateName, cancellationToken)
+                .Returns(response);
 
             _cryptographyClient
-                .Setup(_ => _.CreateRSAAsync(cancellationToken))
-                .ReturnsAsync(rsaKeyVault.Object);
+                .CreateRSAAsync(cancellationToken)
+                .Returns(rsaKeyVault);
 
-            using KeyVaultService service = new(_certificateClient.Object, _cryptographyClient.Object, CertificateName, Logger);
+            using KeyVaultService service = new(_certificateClient, _cryptographyClient, CertificateName, Logger);
 
             using RSA rsa = await service.GetRsaAsync(cancellationToken);
 
             Assert.IsType<RSAKeyVaultWrapper>(rsa);
         }
 
-        private static Mock<KeyVaultCertificateWithPolicy> CreateMockKeyVaultCertificateWithPolicy()
+        private static KeyVaultCertificateWithPolicy CreateKeyVaultCertificateWithPolicy()
         {
-            CertificateProperties certificateProperties = new("test");
             byte[] publicKey = SelfIssuedCertificateCreator.CreateCertificate().Export(X509ContentType.Cert);
-            Mock<KeyVaultCertificateWithPolicy> certificate = new(certificateProperties);
+            return CertificateModelFactory.KeyVaultCertificateWithPolicy(
+                new CertificateProperties("test"),
+                cer: publicKey);
+        }
 
-            // We need to do this because the property has an internal setter
-            typeof(KeyVaultCertificateWithPolicy)
-                .GetProperty(nameof(KeyVaultCertificateWithPolicy.Cer))
-                ?.GetSetMethod(nonPublic: true)
-                ?.Invoke(certificate.Object, [publicKey]);
-
-            return certificate;
+        private static RSAKeyVault CreateRSAKeyVault()
+        {
+#pragma warning disable NS2001 // The Azure SDK grants DynamicProxyGenAssembly2 access to this internal constructor.
+            return Substitute.For<RSAKeyVault>(
+                Substitute.For<CryptographyClient>(),
+                "testId",
+                null);
+#pragma warning restore NS2001
         }
     }
 }

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
@@ -122,7 +122,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
             return Substitute.For<RSAKeyVault>(
                 Substitute.For<CryptographyClient>(),
                 "testId",
-                null);
+                null!);
 #pragma warning restore NS2001
         }
     }

--- a/test/Sign.SignatureProviders.KeyVault.Test/RSAKeyVaultWrapperTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/RSAKeyVaultWrapperTests.cs
@@ -112,7 +112,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
             return Substitute.For<RSAKeyVault>(
                 Substitute.For<CryptographyClient>(),
                 "testId",
-                null);
+                null!);
 #pragma warning restore NS2001
         }
 

--- a/test/Sign.SignatureProviders.KeyVault.Test/RSAKeyVaultWrapperTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/RSAKeyVaultWrapperTests.cs
@@ -39,12 +39,14 @@ namespace Sign.SignatureProviders.KeyVault.Test
             RSAKeyVaultWrapper wrapper = new(rsaKeyVault, rsaPublicKey);
             wrapper.Dispose();
 
-            Assert.Contains(
+            Assert.Single(
                 rsaKeyVault.ReceivedCalls(),
                 call =>
                     call.GetMethodInfo().Name == nameof(RSA.Dispose) &&
+                    call.GetMethodInfo().GetParameters().Length == 1 &&
+                    call.GetMethodInfo().GetParameters()[0].ParameterType == typeof(bool) &&
                     call.GetArguments() is [true]);
-            Assert.True(rsaPublicKey.Disposed);
+            Assert.Equal(1, rsaPublicKey.DisposeTrueCallCount);
         }
 
         [Fact]
@@ -116,11 +118,15 @@ namespace Sign.SignatureProviders.KeyVault.Test
 
         private sealed class RecordingRSA : RSA
         {
-            internal bool Disposed { get; private set; }
+            internal int DisposeTrueCallCount { get; private set; }
 
             protected override void Dispose(bool disposing)
             {
-                Disposed = disposing;
+                if (disposing)
+                {
+                    DisposeTrueCallCount++;
+                }
+
                 base.Dispose(disposing);
             }
 

--- a/test/Sign.SignatureProviders.KeyVault.Test/RSAKeyVaultWrapperTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/RSAKeyVaultWrapperTests.cs
@@ -4,21 +4,20 @@
 
 using System.Security.Cryptography;
 using Azure.Security.KeyVault.Keys.Cryptography;
-using Moq;
-using Moq.Protected;
+using NSubstitute;
 
 namespace Sign.SignatureProviders.KeyVault.Test
 {
     public class RSAKeyVaultWrapperTests
     {
-        private readonly Mock<RSAKeyVault> _rsaKeyVault = new(Mock.Of<CryptographyClient>(), "testId", null);
-        private readonly Mock<RSA> _rsaPublicKey = new();
+        private readonly RSAKeyVault _rsaKeyVault = CreateRSAKeyVault();
+        private readonly RSA _rsaPublicKey = Substitute.For<RSA>();
 
         [Fact]
         public void Constructor_WhenRSAKeyVaultIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new RSAKeyVaultWrapper(rsaKeyVault: null!, _rsaPublicKey.Object));
+                () => new RSAKeyVaultWrapper(rsaKeyVault: null!, _rsaPublicKey));
 
             Assert.Equal("rsaKeyVault", exception.ParamName);
         }
@@ -27,7 +26,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateClientIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new RSAKeyVaultWrapper(_rsaKeyVault.Object, rsaPublicKey: null!));
+                () => new RSAKeyVaultWrapper(_rsaKeyVault, rsaPublicKey: null!));
 
             Assert.Equal("rsaPublicKey", exception.ParamName);
         }
@@ -35,17 +34,23 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [Fact]
         public void Dispose_DisposesRSAKeyVaultAndRSAPublicKey()
         {
-            RSAKeyVaultWrapper wrapper = new(_rsaKeyVault.Object, _rsaPublicKey.Object);
+            RSAKeyVault rsaKeyVault = CreateRSAKeyVault();
+            RecordingRSA rsaPublicKey = new();
+            RSAKeyVaultWrapper wrapper = new(rsaKeyVault, rsaPublicKey);
             wrapper.Dispose();
 
-            _rsaKeyVault.Protected().Verify(nameof(RSAKeyVault.Dispose), Times.Once(), [true]);
-            _rsaPublicKey.Protected().Verify(nameof(RSA.Dispose), Times.Once(), [true]);
+            Assert.Contains(
+                rsaKeyVault.ReceivedCalls(),
+                call =>
+                    call.GetMethodInfo().Name == nameof(RSA.Dispose) &&
+                    call.GetArguments() is [true]);
+            Assert.True(rsaPublicKey.Disposed);
         }
 
         [Fact]
         public void ExportParameters_IncludePrivateParametersIsTrue_Throws()
         {
-            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault.Object, _rsaPublicKey.Object);
+            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault, _rsaPublicKey);
 
             Assert.Throws<NotSupportedException>(
                 () => wrapper.ExportParameters(true));
@@ -54,17 +59,17 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [Fact]
         public void ExportParameters_IncludePrivateParametersIsFalse_UsesExportParametersOfPublicKey()
         {
-            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault.Object, _rsaPublicKey.Object);
+            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault, _rsaPublicKey);
 
             wrapper.ExportParameters(false);
 
-            _rsaPublicKey.Verify(_ => _.ExportParameters(false), Times.Once());
+            _rsaPublicKey.Received(1).ExportParameters(false);
         }
 
         [Fact]
         public void ImportParameters_Throws()
         {
-            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault.Object, _rsaPublicKey.Object);
+            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault, _rsaPublicKey);
 
             Assert.Throws<NotImplementedException>(
                 () => wrapper.ImportParameters(default));
@@ -73,7 +78,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         [Fact]
         public void SignHash_UsesRSAKeyVault()
         {
-            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault.Object, _rsaPublicKey.Object);
+            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault, _rsaPublicKey);
 
             byte[] hash = [];
             HashAlgorithmName hashAlgorithmName = HashAlgorithmName.SHA256;
@@ -81,13 +86,13 @@ namespace Sign.SignatureProviders.KeyVault.Test
 
             wrapper.SignHash(hash, hashAlgorithmName, padding);
 
-            _rsaKeyVault.Verify(_ => _.SignHash(hash, hashAlgorithmName, padding), Times.Once());
+            _rsaKeyVault.Received(1).SignHash(hash, hashAlgorithmName, padding);
         }
 
         [Fact]
         public void VerifyHash_UsesPublicKey()
         {
-            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault.Object, _rsaPublicKey.Object);
+            using RSAKeyVaultWrapper wrapper = new(_rsaKeyVault, _rsaPublicKey);
 
             byte[] hash = [];
             byte[] signature = [];
@@ -96,7 +101,34 @@ namespace Sign.SignatureProviders.KeyVault.Test
 
             wrapper.VerifyHash(hash, signature, hashAlgorithmName, padding);
 
-            _rsaPublicKey.Verify(_ => _.VerifyHash(hash, signature, hashAlgorithmName, padding), Times.Once());
+            _rsaPublicKey.Received(1).VerifyHash(hash, signature, hashAlgorithmName, padding);
+        }
+
+        private static RSAKeyVault CreateRSAKeyVault()
+        {
+#pragma warning disable NS2001 // The Azure SDK grants DynamicProxyGenAssembly2 access to this internal constructor.
+            return Substitute.For<RSAKeyVault>(
+                Substitute.For<CryptographyClient>(),
+                "testId",
+                null);
+#pragma warning restore NS2001
+        }
+
+        private sealed class RecordingRSA : RSA
+        {
+            internal bool Disposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = disposing;
+                base.Dispose(disposing);
+            }
+
+            public override RSAParameters ExportParameters(bool includePrivateParameters) => default;
+
+            public override void ImportParameters(RSAParameters parameters)
+            {
+            }
         }
     }
 }

--- a/test/Sign.SignatureProviders.KeyVault.Test/Sign.SignatureProviders.KeyVault.Test.csproj
+++ b/test/Sign.SignatureProviders.KeyVault.Test/Sign.SignatureProviders.KeyVault.Test.csproj
@@ -12,7 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" PrivateAssets="all" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <IncludeAssets>analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sign.TestInfrastructure/Sign.TestInfrastructure.csproj
+++ b/test/Sign.TestInfrastructure/Sign.TestInfrastructure.csproj
@@ -12,7 +12,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replace Moq across the test suite with NSubstitute so the repository can remove its legacy Moq dependency while preserving existing test behavior and coverage.

## Summary

- Replace centrally managed Moq packages with NSubstitute 6.0.0 and NSubstitute.Analyzers.CSharp 1.0.17.
- Keep package restore on the existing `dotnet-public` feed.
- Migrate routine setups, matchers, async returns, strict expectations, and received-call assertions to idiomatic NSubstitute.
- Replace protected `Dispose(bool)` verification with test-local recording spies.
- Use Azure SDK model/response factories and concrete substitutes for virtual SDK members.
- Remove the stale Moq reference from `Sign.TestInfrastructure` without changing production code.

## Notes for reviewers

`RSAKeyVault` exposes an internal constructor but grants Castle's `DynamicProxyGenAssembly2` friend access. NSubstitute works at runtime, but its analyzer cannot infer that access, so `NS2001` is suppressed only around the two proxy factory calls. The Key Vault tests exercise those proxies successfully.

## Validation

- `eng\common\build.cmd -restore -build -test`
- Build completed with 0 warnings and 0 errors; all test assemblies succeeded.