### PR TITLE
Do not sign ASP.NET Core static web assets in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ While the current version is limited to RSA and Azure Key Vault, it is desirable
 - ClickOnce `.application` and `.vsto` (via `Mage`). Notes below.
 - `.nupkg`
 
+## Static Web Assets
+
+Packages produced by the ASP.NET Core SDK (for example, Blazor and Razor class libraries) carry their browser
+assets in a `staticwebassets` directory and record each asset's integrity hash at pack time in
+`build/Microsoft.AspNetCore.StaticWebAssets.props`.  Signing such an asset --- most commonly a `.js` file, which is
+indistinguishable by extension from a Windows Script Host script --- changes the file and invalidates the recorded
+hash, which breaks consuming applications.
+
+When this tool recurses into a container and finds one of these `.props` files, it skips the assets in the
+package's `staticwebassets` directory and logs a warning for each skipped file.  Files elsewhere in the package,
+including `.js` files outside of `staticwebassets`, are unaffected.
+
+To sign static web assets anyway, list them explicitly using the `--file-list` option.  When a file list is
+provided, this tool signs whatever the list matches.
+
 ## ClickOnce
 There are a couple of possibilities for signing ClickOnce packages.
 

--- a/src/Sign.Core/DataFormatSigners/AggregatingSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/AggregatingSigner.cs
@@ -13,6 +13,7 @@ namespace Sign.Core
         private readonly IFileMetadataService _fileMetadataService;
         private readonly IMatcherFactory _matcherFactory;
         private readonly IEnumerable<IDataFormatSigner> _signers;
+        private readonly IStaticWebAssetFilter _staticWebAssetFilter;
 
         // Dependency injection requires a public constructor.
         public AggregatingSigner(
@@ -20,19 +21,22 @@ namespace Sign.Core
             IDefaultDataFormatSigner defaultSigner,
             IContainerProvider containerProvider,
             IFileMetadataService fileMetadataService,
-            IMatcherFactory matcherFactory)
+            IMatcherFactory matcherFactory,
+            IStaticWebAssetFilter staticWebAssetFilter)
         {
             ArgumentNullException.ThrowIfNull(signers, nameof(signers));
             ArgumentNullException.ThrowIfNull(defaultSigner, nameof(defaultSigner));
             ArgumentNullException.ThrowIfNull(containerProvider, nameof(containerProvider));
             ArgumentNullException.ThrowIfNull(fileMetadataService, nameof(fileMetadataService));
             ArgumentNullException.ThrowIfNull(matcherFactory, nameof(matcherFactory));
+            ArgumentNullException.ThrowIfNull(staticWebAssetFilter, nameof(staticWebAssetFilter));
 
             _signers = signers;
             _defaultSigner = defaultSigner;
             _containerProvider = containerProvider;
             _fileMetadataService = fileMetadataService;
             _matcherFactory = matcherFactory;
+            _staticWebAssetFilter = staticWebAssetFilter;
         }
 
         public bool CanSign(FileInfo file)
@@ -225,7 +229,7 @@ namespace Sign.Core
             }
         }
 
-        private static IEnumerable<FileInfo> GetFiles(IContainer container, SignOptions options)
+        private IEnumerable<FileInfo> GetFiles(IContainer container, SignOptions options)
         {
             IEnumerable<FileInfo> files;
 
@@ -233,6 +237,11 @@ namespace Sign.Core
             {
                 // If not filtered, default to all
                 files = container.GetFiles();
+
+                // ASP.NET Core static web assets have integrity hashes recorded at pack time, and signing
+                // them would invalidate those hashes.  A caller who explicitly listed files to sign has
+                // already stated an intent, so only filter when no file list was provided.
+                files = _staticWebAssetFilter.Filter(files);
             }
             else
             {

--- a/src/Sign.Core/FileSystem/IStaticWebAssetFilter.cs
+++ b/src/Sign.Core/FileSystem/IStaticWebAssetFilter.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal interface IStaticWebAssetFilter
+    {
+        IReadOnlyList<FileInfo> Filter(IEnumerable<FileInfo> files);
+    }
+}

--- a/src/Sign.Core/FileSystem/StaticWebAssetFilter.cs
+++ b/src/Sign.Core/FileSystem/StaticWebAssetFilter.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Sign.Core
+{
+    /// <summary>
+    /// Excludes ASP.NET Core static web assets from signing.
+    /// </summary>
+    /// <remarks>
+    /// Packages produced by the ASP.NET Core SDK (for example, Blazor and Razor class libraries) carry their
+    /// browser assets in a <c>staticwebassets</c> directory and record each asset's integrity hash at pack time in
+    /// <c>build/Microsoft.AspNetCore.StaticWebAssets.props</c>.  Signing such an asset --- most commonly a .js
+    /// file, which is indistinguishable by extension from a Windows Script Host script --- changes the file and
+    /// invalidates the recorded hash, which breaks consuming applications.
+    /// See https://github.com/dotnet/sign/issues/1045.
+    /// </remarks>
+    internal sealed class StaticWebAssetFilter : IStaticWebAssetFilter
+    {
+        // Matches Microsoft.AspNetCore.StaticWebAssets.props and, for .NET 9 and later,
+        // Microsoft.AspNetCore.StaticWebAssetEndpoints.props.
+        private const string MarkerFileNamePrefix = "Microsoft.AspNetCore.StaticWebAsset";
+        private const string MarkerFileNameExtension = ".props";
+        private const string StaticWebAssetsDirectoryName = "staticwebassets";
+
+        private static readonly HashSet<string> BuildDirectoryNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "build",
+            "buildMultiTargeting",
+            "buildTransitive"
+        };
+
+        private readonly ILogger<IStaticWebAssetFilter> _logger;
+
+        // Dependency injection requires a public constructor.
+        public StaticWebAssetFilter(ILogger<IStaticWebAssetFilter> logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
+
+            _logger = logger;
+        }
+
+        public IReadOnlyList<FileInfo> Filter(IEnumerable<FileInfo> files)
+        {
+            ArgumentNullException.ThrowIfNull(files, nameof(files));
+
+            List<FileInfo> allFiles = files.ToList();
+            Dictionary<string, string> staticWebAssetDirectories = GetStaticWebAssetDirectories(allFiles);
+
+            if (staticWebAssetDirectories.Count == 0)
+            {
+                return allFiles;
+            }
+
+            List<FileInfo> filesToSign = new(allFiles.Count);
+
+            foreach (FileInfo file in allFiles)
+            {
+                string? markerFileName = GetMarkerFileName(file, staticWebAssetDirectories);
+
+                if (markerFileName is null)
+                {
+                    filesToSign.Add(file);
+                }
+                else
+                {
+                    _logger.LogWarning(Resources.SkippingStaticWebAsset, file.FullName, markerFileName);
+                }
+            }
+
+            return filesToSign;
+        }
+
+        /// <summary>
+        /// Finds each static web assets directory implied by a marker file.
+        /// </summary>
+        /// <returns>A dictionary of static web assets directory path to the name of the marker file that
+        /// identified it.</returns>
+        private static Dictionary<string, string> GetStaticWebAssetDirectories(IReadOnlyList<FileInfo> files)
+        {
+            Dictionary<string, string> directories = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (FileInfo file in files)
+            {
+                if (!IsMarkerFile(file))
+                {
+                    continue;
+                }
+
+                // The marker file is <package root>/build/Microsoft.AspNetCore.StaticWebAssets.props,
+                // and the assets it describes are under <package root>/staticwebassets.
+                DirectoryInfo? packageRootDirectory = file.Directory?.Parent;
+
+                if (packageRootDirectory is null)
+                {
+                    continue;
+                }
+
+                string staticWebAssetsDirectoryPath = Path.Combine(
+                    packageRootDirectory.FullName,
+                    StaticWebAssetsDirectoryName);
+
+                directories[staticWebAssetsDirectoryPath] = file.Name;
+            }
+
+            return directories;
+        }
+
+        private static bool IsMarkerFile(FileInfo file)
+        {
+            return file.Name.StartsWith(MarkerFileNamePrefix, StringComparison.OrdinalIgnoreCase)
+                && file.Name.EndsWith(MarkerFileNameExtension, StringComparison.OrdinalIgnoreCase)
+                && file.Directory is not null
+                && BuildDirectoryNames.Contains(file.Directory.Name);
+        }
+
+        /// <summary>
+        /// Gets the name of the marker file identifying <paramref name="file" /> as a static web asset,
+        /// or <c>null</c> if the file is not a static web asset.
+        /// </summary>
+        private static string? GetMarkerFileName(FileInfo file, Dictionary<string, string> staticWebAssetDirectories)
+        {
+            foreach (KeyValuePair<string, string> staticWebAssetDirectory in staticWebAssetDirectories)
+            {
+                string directoryPathPrefix = staticWebAssetDirectory.Key + Path.DirectorySeparatorChar;
+
+                if (file.FullName.StartsWith(directoryPathPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return staticWebAssetDirectory.Value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -331,6 +331,15 @@ namespace Sign.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option..
+        /// </summary>
+        internal static string SkippingStaticWebAsset {
+            get {
+                return ResourceManager.GetString("SkippingStaticWebAsset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Submitting {filePath} for signing..
         /// </summary>
         internal static string SubmittingFileForSigning {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -231,6 +231,10 @@
     <value>Completed in {millseconds} ms.</value>
     <comment>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</comment>
   </data>
+  <data name="SkippingStaticWebAsset" xml:space="preserve">
+    <value>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</value>
+    <comment>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</comment>
+  </data>
   <data name="SubmittingFileForSigning" xml:space="preserve">
     <value>Submitting {filePath} for signing.</value>
     <comment>{Placeholder="{filePath}"} is a file path.</comment>

--- a/src/Sign.Core/ServiceProvider.cs
+++ b/src/Sign.Core/ServiceProvider.cs
@@ -62,6 +62,7 @@ namespace Sign.Core
             services.AddSingleton<IContainerProvider, ContainerProvider>();
             services.AddSingleton<IFileMetadataService, FileMetadataService>();
             services.AddSingleton<IDirectoryService, DirectoryService>();
+            services.AddSingleton<IStaticWebAssetFilter, StaticWebAssetFilter>();
             services.AddSingleton<IDataFormatSigner, AzureSignToolSigner>();
             services.AddSingleton<IDataFormatSigner, ClickOnceSigner>();
             services.AddSingleton<IDataFormatSigner, VsixSigner>();

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Dokončeno za {millseconds} ms.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Odesílá se soubor {filePath} pro podepisování.</target>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">In {millseconds} ms abgeschlossen.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">{filePath} wird zum Signieren übermittelt.</target>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Completado en {millseconds} ms.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Enviando {filePath} para la firma.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Terminé en {millseconds} ms.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Envoi de {filePath} pour signature.</target>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Completato in {millseconds} ms.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Invio {filePath} per la firma.</target>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">{millseconds} ミリ秒で完了しました</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">署名のために {filePath} を送信しています。</target>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">{millseconds} 밀리초 후에 완료되었습니다.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">서명을 위해 {filePath}을(를) 제출하는 중입니다.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Ukończono w {millseconds} ms.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Przesyłanie ścieżki {filePath} do podpisania.</target>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Concluído em {millseconds} ms.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Enviando {filePath} para autenticação.</target>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Завершено за {millseconds} мс.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">Отправка {filePath} для подписывания.</target>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">{millseconds} ms içinde tamamlandı.</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">{filePath} imzalama için gönderiliyor.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">已完成时间(以 {millseconds} 毫秒为单位)。</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">正在提交 {filePath} 进行签名。</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">已在 {millseconds} 毫秒內完成。</target>
         <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
+      <trans-unit id="SkippingStaticWebAsset">
+        <source>Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</source>
+        <target state="new">Skipping {filePath}. It is an ASP.NET Core static web asset, and signing it would invalidate the integrity hash recorded in {propsFileName}. To sign it anyway, list it explicitly using the --file-list option.</target>
+        <note>{Placeholder="{filePath}"} is a file path. {Placeholder="{propsFileName}"} is a file name. "--file-list" is a command line option name and should not be translated.</note>
+      </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
         <target state="translated">正在提交 {filePath} 進行簽署。</target>

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
@@ -12,6 +12,7 @@ namespace Sign.Core.Test
     {
         private const string AppxBundleContainerName = "container.appxbundle";
         private const string AppxContainerName = "container.appx";
+        private const string NuGetContainerName = "container.nupkg";
         private const string ZipContainerName = "container.zip";
 
         [Fact]
@@ -433,6 +434,64 @@ namespace Sign.Core.Test
                 signedFile => Assert.Equal("e.EXE", signedFile.Name),
                 signedFile => Assert.Equal("g.dll", signedFile.Name),
                 signedFile => Assert.Equal("i.exe", signedFile.Name));
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenNuGetContainerHasStaticWebAssets_DoesNotSignStaticWebAssets()
+        {
+            AggregatingSignerTest test = new(
+                $"{NuGetContainerName}/build/Microsoft.AspNetCore.StaticWebAssets.props",
+                $"{NuGetContainerName}/staticwebassets/app.js",
+                $"{NuGetContainerName}/lib/net8.0/a.dll",
+                $"{NuGetContainerName}/tools/script.js");
+
+            await test.Signer.SignAsync(test.Files, _options);
+
+            ContainerSpy container = test.Containers[NuGetContainerName];
+
+            Assert.Equal(1, container.OpenAsync_CallCount);
+            Assert.Equal(1, container.GetFiles_CallCount);
+            Assert.Equal(0, container.GetFilesWithMatcher_CallCount);
+            Assert.Equal(1, container.SaveAsync_CallCount);
+            Assert.Equal(1, container.Dispose_CallCount);
+
+            // The static web asset is skipped; the Windows Script Host script in tools is not.
+            Assert.Collection(
+                test.SignerSpy.SignedFiles,
+                signedFile => Assert.Equal("a.dll", signedFile.Name),
+                signedFile => Assert.Equal("script.js", signedFile.Name),
+                signedFile => Assert.Equal(NuGetContainerName, signedFile.Name));
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenNuGetContainerHasStaticWebAssetsAndGlobPatternIsUsed_SignsMatchingFiles()
+        {
+            const string fileListContents = "**/*.js";
+            ReadFileList(fileListContents, out Matcher matcher, out Matcher antiMatcher);
+
+            SignOptions options = new(
+                applicationName: null,
+                publisherName: null,
+                description: null,
+                descriptionUrl: new Uri("https://description.test"),
+                fileHashAlgorithm: HashAlgorithmName.SHA256,
+                timestampHashAlgorithm: HashAlgorithmName.SHA256,
+                timestampService: new Uri("https://timestamp.test"),
+                matcher,
+                antiMatcher,
+                recurseContainers: true);
+
+            AggregatingSignerTest test = new(
+                $"{NuGetContainerName}/build/Microsoft.AspNetCore.StaticWebAssets.props",
+                $"{NuGetContainerName}/staticwebassets/app.js");
+
+            await test.Signer.SignAsync(test.Files, options);
+
+            // An explicit file list is an explicit intent, so static web assets are not filtered out.
+            Assert.Collection(
+                test.SignerSpy.SignedFiles,
+                signedFile => Assert.Equal("app.js", signedFile.Name),
+                signedFile => Assert.Equal(NuGetContainerName, signedFile.Name));
         }
 
         private static void ReadFileList(string contents, out Matcher matcher, out Matcher antiMatcher)

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.cs
@@ -21,7 +21,8 @@ namespace Sign.Core.Test
                     Substitute.For<IDefaultDataFormatSigner>(),
                     Substitute.For<IContainerProvider>(),
                     Substitute.For<IFileMetadataService>(),
-                    Substitute.For<IMatcherFactory>()));
+                    Substitute.For<IMatcherFactory>(),
+                    Substitute.For<IStaticWebAssetFilter>()));
 
             Assert.Equal("signers", exception.ParamName);
         }
@@ -35,7 +36,8 @@ namespace Sign.Core.Test
                     defaultSigner: null!,
                     Substitute.For<IContainerProvider>(),
                     Substitute.For<IFileMetadataService>(),
-                    Substitute.For<IMatcherFactory>()));
+                    Substitute.For<IMatcherFactory>(),
+                    Substitute.For<IStaticWebAssetFilter>()));
 
             Assert.Equal("defaultSigner", exception.ParamName);
         }
@@ -49,7 +51,8 @@ namespace Sign.Core.Test
                     Substitute.For<IDefaultDataFormatSigner>(),
                     containerProvider: null!,
                     Substitute.For<IFileMetadataService>(),
-                    Substitute.For<IMatcherFactory>()));
+                    Substitute.For<IMatcherFactory>(),
+                    Substitute.For<IStaticWebAssetFilter>()));
 
             Assert.Equal("containerProvider", exception.ParamName);
         }
@@ -63,7 +66,8 @@ namespace Sign.Core.Test
                     Substitute.For<IDefaultDataFormatSigner>(),
                     Substitute.For<IContainerProvider>(),
                     fileMetadataService: null!,
-                    Substitute.For<IMatcherFactory>()));
+                    Substitute.For<IMatcherFactory>(),
+                    Substitute.For<IStaticWebAssetFilter>()));
 
             Assert.Equal("fileMetadataService", exception.ParamName);
         }
@@ -77,9 +81,25 @@ namespace Sign.Core.Test
                     Substitute.For<IDefaultDataFormatSigner>(),
                     Substitute.For<IContainerProvider>(),
                     Substitute.For<IFileMetadataService>(),
-                    matcherFactory: null!));
+                    matcherFactory: null!,
+                    Substitute.For<IStaticWebAssetFilter>()));
 
             Assert.Equal("matcherFactory", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenStaticWebAssetFilterIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new AggregatingSigner(
+                    Enumerable.Empty<IDataFormatSigner>(),
+                    Substitute.For<IDefaultDataFormatSigner>(),
+                    Substitute.For<IContainerProvider>(),
+                    Substitute.For<IFileMetadataService>(),
+                    Substitute.For<IMatcherFactory>(),
+                    staticWebAssetFilter: null!));
+
+            Assert.Equal("staticWebAssetFilter", exception.ParamName);
         }
 
         [Fact]
@@ -186,7 +206,8 @@ namespace Sign.Core.Test
                 Substitute.For<IDefaultDataFormatSigner>(),
                 Substitute.For<IContainerProvider>(),
                 Substitute.For<IFileMetadataService>(),
-                matcherFactory);
+                matcherFactory,
+                Substitute.For<IStaticWebAssetFilter>());
         }
     }
 }

--- a/test/Sign.Core.Test/FileSystem/StaticWebAssetFilterTests.cs
+++ b/test/Sign.Core.Test/FileSystem/StaticWebAssetFilterTests.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Sign.Core.Test
+{
+    public class StaticWebAssetFilterTests
+    {
+        private static readonly string PackageRootDirectoryPath = Path.Combine(Path.GetTempPath(), "package");
+
+        private readonly StaticWebAssetFilter _filter;
+
+        public StaticWebAssetFilterTests()
+        {
+            _filter = new StaticWebAssetFilter(Substitute.For<ILogger<IStaticWebAssetFilter>>());
+        }
+
+        [Fact]
+        public void Constructor_WhenLoggerIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new StaticWebAssetFilter(logger: null!));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void Filter_WhenFilesIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _filter.Filter(files: null!));
+
+            Assert.Equal("files", exception.ParamName);
+        }
+
+        [Fact]
+        public void Filter_WhenFilesIsEmpty_ReturnsEmpty()
+        {
+            IReadOnlyList<FileInfo> files = _filter.Filter(Enumerable.Empty<FileInfo>());
+
+            Assert.Empty(files);
+        }
+
+        [Fact]
+        public void Filter_WhenPropsFileIsMissing_ReturnsAllFiles()
+        {
+            // Without the marker file, a .js file is indistinguishable from a Windows Script Host script.
+            AssertFilter(
+                files: new[] { "staticwebassets/app.js", "lib/net8.0/a.dll" },
+                expectedFilesToSign: new[] { "staticwebassets/app.js", "lib/net8.0/a.dll" });
+        }
+
+        [Theory]
+        [InlineData("build")]
+        [InlineData("buildMultiTargeting")]
+        [InlineData("buildTransitive")]
+        [InlineData("BUILD")] // test case insensitivity
+        public void Filter_WhenPropsFileIsInBuildDirectory_ExcludesStaticWebAssets(string buildDirectoryName)
+        {
+            AssertFilter(
+                files: new[]
+                {
+                    $"{buildDirectoryName}/Microsoft.AspNetCore.StaticWebAssets.props",
+                    "staticwebassets/app.js",
+                    "lib/net8.0/a.dll"
+                },
+                expectedFilesToSign: new[]
+                {
+                    $"{buildDirectoryName}/Microsoft.AspNetCore.StaticWebAssets.props",
+                    "lib/net8.0/a.dll"
+                });
+        }
+
+        [Theory]
+        [InlineData("Microsoft.AspNetCore.StaticWebAssets.props")]
+        [InlineData("Microsoft.AspNetCore.StaticWebAssetEndpoints.props")] // .NET 9 and later
+        [InlineData("microsoft.aspnetcore.staticwebassets.props")] // test case insensitivity
+        public void Filter_WhenPropsFileNameIsRecognized_ExcludesStaticWebAssets(string propsFileName)
+        {
+            AssertFilter(
+                files: new[] { $"build/{propsFileName}", "staticwebassets/app.js" },
+                expectedFilesToSign: new[] { $"build/{propsFileName}" });
+        }
+
+        [Fact]
+        public void Filter_WhenPropsFileIsNotInBuildDirectory_ReturnsAllFiles()
+        {
+            AssertFilter(
+                files: new[] { "Microsoft.AspNetCore.StaticWebAssets.props", "staticwebassets/app.js" },
+                expectedFilesToSign: new[] { "Microsoft.AspNetCore.StaticWebAssets.props", "staticwebassets/app.js" });
+        }
+
+        [Fact]
+        public void Filter_WhenPropsFileNameIsUnrelated_ReturnsAllFiles()
+        {
+            AssertFilter(
+                files: new[] { "build/MyPackage.props", "staticwebassets/app.js" },
+                expectedFilesToSign: new[] { "build/MyPackage.props", "staticwebassets/app.js" });
+        }
+
+        [Theory]
+        [InlineData("staticwebassets/app.js")]
+        [InlineData("staticwebassets/_framework/a.dll")]
+        [InlineData("staticwebassets/_framework/dotnet.native.wasm")]
+        [InlineData("staticwebassets/js/nested/directory/app.js")]
+        [InlineData("STATICWEBASSETS/app.js")] // test case insensitivity
+        public void Filter_WhenFileIsStaticWebAsset_ExcludesFile(string filePath)
+        {
+            AssertFilter(
+                files: new[] { "build/Microsoft.AspNetCore.StaticWebAssets.props", filePath },
+                expectedFilesToSign: new[] { "build/Microsoft.AspNetCore.StaticWebAssets.props" });
+        }
+
+        [Theory]
+        [InlineData("tools/script.js")] // a Windows Script Host script
+        [InlineData("contentFiles/any/any/script.js")]
+        [InlineData("staticwebassetsdocs/app.js")] // similarly named directory
+        public void Filter_WhenFileIsNotStaticWebAsset_ReturnsFile(string filePath)
+        {
+            AssertFilter(
+                files: new[] { "build/Microsoft.AspNetCore.StaticWebAssets.props", filePath },
+                expectedFilesToSign: new[] { "build/Microsoft.AspNetCore.StaticWebAssets.props", filePath });
+        }
+
+        [Fact]
+        public void Filter_WhenStaticWebAssetsDirectoryIsNotUnderPackageRoot_ReturnsFile()
+        {
+            // The props file identifies its own package's static web assets, not another package's.
+            AssertFilter(
+                files: new[]
+                {
+                    "build/Microsoft.AspNetCore.StaticWebAssets.props",
+                    "tools/staticwebassets/app.js"
+                },
+                expectedFilesToSign: new[]
+                {
+                    "build/Microsoft.AspNetCore.StaticWebAssets.props",
+                    "tools/staticwebassets/app.js"
+                });
+        }
+
+        [Fact]
+        public void Filter_WhenFileIsStaticWebAsset_LogsWarning()
+        {
+            Logger logger = new();
+            StaticWebAssetFilter filter = new(logger);
+
+            filter.Filter(GetFiles("build/Microsoft.AspNetCore.StaticWebAssets.props", "staticwebassets/app.js"));
+
+            Assert.Equal(1, logger.Log_CallCount);
+        }
+
+        [Fact]
+        public void Filter_WhenNoFileIsStaticWebAsset_LogsNothing()
+        {
+            Logger logger = new();
+            StaticWebAssetFilter filter = new(logger);
+
+            filter.Filter(GetFiles("lib/net8.0/a.dll", "tools/script.js"));
+
+            Assert.Equal(0, logger.Log_CallCount);
+        }
+
+        private void AssertFilter(string[] files, string[] expectedFilesToSign)
+        {
+            IReadOnlyList<FileInfo> actualFilesToSign = _filter.Filter(GetFiles(files));
+
+            Assert.Equal(
+                GetFiles(expectedFilesToSign).Select(file => file.FullName),
+                actualFilesToSign.Select(file => file.FullName));
+        }
+
+        private static IReadOnlyList<FileInfo> GetFiles(params string[] relativeFilePaths)
+        {
+            return relativeFilePaths
+                .Select(relativeFilePath => new FileInfo(
+                    Path.Combine(
+                        PackageRootDirectoryPath,
+                        relativeFilePath.Replace('/', Path.DirectorySeparatorChar))))
+                .ToList();
+        }
+
+        private sealed class Logger : ILogger<IStaticWebAssetFilter>
+        {
+            internal int Log_CallCount { get; private set; }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            {
+                return new NoOpDisposable();
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                ++Log_CallCount;
+
+                Assert.Equal(LogLevel.Warning, logLevel);
+            }
+
+            private sealed class NoOpDisposable : IDisposable
+            {
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/test/Sign.Core.Test/ServiceProviderTests.cs
+++ b/test/Sign.Core.Test/ServiceProviderTests.cs
@@ -41,6 +41,7 @@ namespace Sign.Core.Test
             Assert.NotNull(serviceProvider.GetRequiredService<IContainerProvider>());
             Assert.NotNull(serviceProvider.GetRequiredService<IFileMetadataService>());
             Assert.NotNull(serviceProvider.GetRequiredService<IDirectoryService>());
+            Assert.NotNull(serviceProvider.GetRequiredService<IStaticWebAssetFilter>());
             Assert.NotNull(serviceProvider.GetRequiredService<ISignatureAlgorithmProvider>());
             Assert.NotNull(serviceProvider.GetRequiredService<ICertificateProvider>());
 

--- a/test/Sign.Core.Test/SignerTests.cs
+++ b/test/Sign.Core.Test/SignerTests.cs
@@ -563,6 +563,7 @@ namespace Sign.Core.Test
             services.AddSingleton<IContainerProvider, ContainerProvider>();
             services.AddSingleton<IFileMetadataService, FileMetadataService>();
             services.AddSingleton<IDirectoryService, DirectoryService>();
+            services.AddSingleton<IStaticWebAssetFilter, StaticWebAssetFilter>();
             services.AddSingleton<ISignatureAlgorithmProvider>(_keyVaultServiceStub);
             services.AddSingleton<ICertificateProvider>(_keyVaultServiceStub);
             services.AddSingleton<IDataFormatSigner, AzureSignToolSigner>();

--- a/test/Sign.Core.Test/TestInfrastructure/AggregatingSignerTest.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/AggregatingSignerTest.cs
@@ -177,7 +177,8 @@ namespace Sign.Core.Test
                 SignerSpy,
                 _containerProvider,
                 fileMetadataService,
-                new MatcherFactory());
+                new MatcherFactory(),
+                new StaticWebAssetFilter(Substitute.For<ILogger<IStaticWebAssetFilter>>()));
             _containerProvider.Containers = Containers.Values.ToList();
         }
     }


### PR DESCRIPTION
Fixes #1045

## Problem

Packages produced by the ASP.NET Core SDK (Blazor and Razor class libraries) carry their browser assets in a `staticwebassets` directory and record each asset's integrity hash at pack time in `build/Microsoft.AspNetCore.StaticWebAssets.props`.

`.js` is in the signable extension list because Windows Script Host scripts are `.js`, so recursing into such a package signs its `.js` assets. That changes the files, invalidates the recorded hashes, and consuming applications fail with an integrity conflict. The workaround reported in #1045 was `--recurse-containers false`, which gives up signing the package contents entirely.

## Change

When recursing into a container, `AggregatingSigner` now skips the files in a package's `staticwebassets` directory and logs a warning naming each skipped file.

Detection is convention-based and scoped to the package that declares the assets:

* A package is recognized by a `Microsoft.AspNetCore.StaticWebAsset*.props` file in its `build`, `buildTransitive`, or `buildMultiTargeting` directory. The wildcard also covers `Microsoft.AspNetCore.StaticWebAssetEndpoints.props` (.NET 9 and later).
* Only that package's own `staticwebassets` directory is skipped --- a `staticwebassets` directory elsewhere in the container is not.
* Files elsewhere in the package are unaffected, including `.js` files outside of `staticwebassets`, so genuine Windows Script Host scripts are still signed.

Filtering applies only when no file list was provided. A caller who explicitly listed files has already stated an intent, so static web assets can still be signed by listing them with `--file-list`.

The new `IStaticWebAssetFilter` works on the file paths already enumerated from the container, so it adds no `IContainer.GetFiles(...)` calls.

## Notes

* This changes default behavior: files that were previously signed inside static web asset packages are now skipped, with a warning. Signing a file that a browser integrity-checks is never the intent, so this seemed preferable to a warning-only change, but I am happy to switch to warning-only or to add an opt-out option if you would rather not change the default.
* One new resource string, with the `.xlf` files updated by the build.

## Testing

* New `StaticWebAssetFilterTests` covering the marker file locations and names, non-`.js` assets (`.wasm`, `.dll`), a `.js` file outside `staticwebassets`, a similarly named directory, case insensitivity, and the warning.
* New `AggregatingSignerTests` cases for a `.nupkg` container with and without a file list.
* I developed this on macOS, where `Sign.Core.Test` compiles but cannot run (the projects are `win-x64` and `Sign.TestInfrastructure` needs `mage.exe`). I verified the new and existing `AggregatingSigner` tests --- 55 in total --- by compiling the same sources into a scratch `net8.0` project and running them locally; they all pass. CI is the first Windows run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)